### PR TITLE
squid:S1197 - Array designators should be on the type, not the variable

### DIFF
--- a/jolivia.airplay/src/main/java/com/beatofthedrum/alacdecoder/AlacFile.java
+++ b/jolivia.airplay/src/main/java/com/beatofthedrum/alacdecoder/AlacFile.java
@@ -13,7 +13,7 @@ package com.beatofthedrum.alacdecoder;
 public class AlacFile
 {
 
-	byte input_buffer[];
+	byte[] input_buffer;
 	int ibIdx = 0;
 	int input_buffer_bitaccumulator = 0; /*
 										 * used so we can do arbitary bit reads
@@ -27,14 +27,14 @@ public class AlacFile
 
 	private int buffer_size = 16384;
 	/* buffers */
-	int predicterror_buffer_a[] = new int[buffer_size];
-	int predicterror_buffer_b[] = new int[buffer_size];
+	int[] predicterror_buffer_a = new int[buffer_size];
+	int[] predicterror_buffer_b = new int[buffer_size];
 
-	int outputsamples_buffer_a[] = new int[buffer_size];
-	int outputsamples_buffer_b[] = new int[buffer_size];
+	int[] outputsamples_buffer_a = new int[buffer_size];
+	int[] outputsamples_buffer_b = new int[buffer_size];
 
-	int uncompressed_bytes_buffer_a[] = new int[buffer_size];
-	int uncompressed_bytes_buffer_b[] = new int[buffer_size];
+	int[] uncompressed_bytes_buffer_a = new int[buffer_size];
+	int[] uncompressed_bytes_buffer_b = new int[buffer_size];
 
 	/* stuff from setinfo */
 	public int setinfo_max_samples_per_frame = 0; // 0x1000 = 4096

--- a/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/client/model/DeviceConnection.java
+++ b/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/client/model/DeviceConnection.java
@@ -84,7 +84,7 @@ public class DeviceConnection
 			if(contentLength > 0)
 			{
 				content = new StringBuffer(contentLength);
-				char buffer[] = new char[1024];
+				char[] buffer = new char[1024];
 				int read, totalRead = 0;
 				do
 				{

--- a/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/client/model/DeviceResponse.java
+++ b/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/client/model/DeviceResponse.java
@@ -18,16 +18,16 @@ public class DeviceResponse
 
 	public DeviceResponse(String headers, String content)
 	{
-		String headerSplit[] = headers.split("\n");
+		String[] headerSplit = headers.split("\n");
 
 		String rawResponseValue = headerSplit[0];
-		String responseSplit[] = rawResponseValue.split(" ");
+		String[] responseSplit = rawResponseValue.split(" ");
 		responseCode = Integer.parseInt(responseSplit[1]);
 		responseMessage = responseSplit[2];
 
 		for(int i = 1; i < headerSplit.length; i++)
 		{
-			String headerValueSplit[] = headerSplit[i].split(":");
+			String[] headerValueSplit = headerSplit[i].split(":");
 			headerMap.put(headerValueSplit[0], headerValueSplit[1].trim());
 		}
 
@@ -39,7 +39,7 @@ public class DeviceResponse
 			{
 				for(String paramLine : content.split("\n"))
 				{
-					String paramSplit[] = paramLine.split(":");
+					String[] paramSplit = paramLine.split(":");
 					contentParameterMap.put(paramSplit[0], paramSplit[1].trim());
 				}
 			}

--- a/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/airreceiver/RunningWeightedAverage.java
+++ b/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/airreceiver/RunningWeightedAverage.java
@@ -20,8 +20,8 @@ package org.dyndns.jkiddo.raop.server.airreceiver;
 public class RunningWeightedAverage
 {
 	public final int m_length;
-	public final double m_values[];
-	public final double m_weights[];
+	public final double[] m_values;
+	public final double[] m_weights;
 	public boolean m_empty = true;
 	public int m_index = 0;
 	public double m_average = Double.NaN;

--- a/jolivia.dacp/src/main/java/org/dyndns/jkiddo/service/dacp/client/TouchRemoteResource.java
+++ b/jolivia.dacp/src/main/java/org/dyndns/jkiddo/service/dacp/client/TouchRemoteResource.java
@@ -133,7 +133,7 @@ public class TouchRemoteResource extends MDNSResource implements ITouchRemoteRes
 		final ByteArrayOutputStream os = new ByteArrayOutputStream();
 		os.write(databaseCode.getBytes("UTF-8"));
 
-		final byte codeAsBytes[] = String.format("%04d", actualCode).getBytes("UTF-8");
+		final byte[] codeAsBytes = String.format("%04d", actualCode).getBytes("UTF-8");
 		for (final byte codeAsByte : codeAsBytes) {
 			os.write(codeAsByte);
 			os.write(0);

--- a/jolivia.jetty/src/main/java/org/dyndns/jkiddo/service/dmap/CustomByteArrayProvider.java
+++ b/jolivia.jetty/src/main/java/org/dyndns/jkiddo/service/dmap/CustomByteArrayProvider.java
@@ -32,7 +32,7 @@ public class CustomByteArrayProvider extends AbstractMessageReaderWriterProvider
 		return type == byte[].class;
 	}
 
-	public byte[] readFrom(Class<byte[]> type, Type genericType, Annotation annotations[], MediaType mediaType, MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException
+	public byte[] readFrom(Class<byte[]> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException
 	{
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
 		writeTo(entityStream, out);
@@ -44,7 +44,7 @@ public class CustomByteArrayProvider extends AbstractMessageReaderWriterProvider
 		return type == byte[].class;
 	}
 
-	public void writeTo(byte[] t, Class<?> type, Type genericType, Annotation annotations[], MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException
+	public void writeTo(byte[] t, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException
 	{
 		entityStream.write(t);
 	}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1197 - Array designators should be on the type, not the variable

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1197

Please let me know if you have any questions.

M-Ezzat