### PR TITLE
squid:S3052 - Fields should not be initialized to default values

### DIFF
--- a/jolivia.airplay/src/main/java/com/beatofthedrum/alacdecoder/AlacFile.java
+++ b/jolivia.airplay/src/main/java/com/beatofthedrum/alacdecoder/AlacFile.java
@@ -14,14 +14,14 @@ public class AlacFile
 {
 
 	byte[] input_buffer;
-	int ibIdx = 0;
-	int input_buffer_bitaccumulator = 0; /*
+	int ibIdx;
+	int input_buffer_bitaccumulator; /*
 										 * used so we can do arbitary bit reads
 										 */
 
-	int samplesize = 0;
-	int numchannels = 0;
-	int bytespersample = 0;
+	int samplesize;
+	int numchannels;
+	int bytespersample;
 
 	LeadingZeros lz = new LeadingZeros();
 
@@ -37,21 +37,21 @@ public class AlacFile
 	int[] uncompressed_bytes_buffer_b = new int[buffer_size];
 
 	/* stuff from setinfo */
-	public int setinfo_max_samples_per_frame = 0; // 0x1000 = 4096
+	public int setinfo_max_samples_per_frame; // 0x1000 = 4096
 	/* max samples per frame? */
 
-	public int setinfo_7a = 0; // 0x00
-	public int setinfo_sample_size = 0; // 0x10
-	public int setinfo_rice_historymult = 0; // 0x28
-	public int setinfo_rice_initialhistory = 0; // 0x0a
-	public int setinfo_rice_kmodifier = 0; // 0x0e
-	public int setinfo_7f = 0; // 0x02
-	public int setinfo_80 = 0; // 0x00ff
-	public int setinfo_82 = 0; // 0x000020e7
+	public int setinfo_7a; // 0x00
+	public int setinfo_sample_size; // 0x10
+	public int setinfo_rice_historymult; // 0x28
+	public int setinfo_rice_initialhistory; // 0x0a
+	public int setinfo_rice_kmodifier; // 0x0e
+	public int setinfo_7f; // 0x02
+	public int setinfo_80; // 0x00ff
+	public int setinfo_82; // 0x000020e7
 	/* max sample size?? */
-	public int setinfo_86 = 0; // 0x00069fe4
+	public int setinfo_86; // 0x00069fe4
 	/* bit rate (avarge)?? */
-	public int setinfo_8a_rate = 0; // 0x0000ac44
+	public int setinfo_8a_rate; // 0x0000ac44
 	/* end setinfo stuff */
 
 	public int[] predictor_coef_table = new int[1024];

--- a/jolivia.airplay/src/main/java/com/beatofthedrum/alacdecoder/LeadingZeros.java
+++ b/jolivia.airplay/src/main/java/com/beatofthedrum/alacdecoder/LeadingZeros.java
@@ -13,6 +13,6 @@ package com.beatofthedrum.alacdecoder;
 
 class LeadingZeros
 {
-	public int curbyte = 0;
-	public int output = 0;
+	public int curbyte;
+	public int output;
 }

--- a/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/airreceiver/AudioOutputQueue.java
+++ b/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/airreceiver/AudioOutputQueue.java
@@ -43,7 +43,7 @@ public class AudioOutputQueue implements AudioClock
 	/**
 	 * Signals that the queue is being closed. Never transitions from true to false!
 	 */
-	private volatile boolean m_closing = false;
+	private volatile boolean m_closing;
 
 	/**
 	 * The line's audio format
@@ -93,17 +93,17 @@ public class AudioOutputQueue implements AudioClock
 	/**
 	 * Number of frames appended to the line
 	 */
-	private long m_lineFramesWritten = 0;
+	private long m_lineFramesWritten;
 
 	/**
 	 * Largest frame time seen so far
 	 */
-	private long m_latestSeenFrameTime = 0;
+	private long m_latestSeenFrameTime;
 
 	/**
 	 * The frame time corresponding to line time zero
 	 */
-	private long m_frameTimeOffset = 0;
+	private long m_frameTimeOffset;
 
 	/**
 	 * The seconds time corresponding to line time zero
@@ -113,7 +113,7 @@ public class AudioOutputQueue implements AudioClock
 	/**
 	 * Requested line gain
 	 */
-	private float m_requestedGain = 0.0f;
+	private float m_requestedGain;
 
 	/**
 	 * Enqueuer thread

--- a/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/airreceiver/RaopRtpRetransmitRequestHandler.java
+++ b/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/airreceiver/RaopRtpRetransmitRequestHandler.java
@@ -69,7 +69,7 @@ public class RaopRtpRetransmitRequestHandler extends SimpleChannelUpstreamHandle
 		/**
 		 * Number of retransmit requests already sent for the packet
 		 */
-		public int retransmitRequestCount = 0;
+		public int retransmitRequestCount;
 
 		/**
 		 * Packet expected to arrive until this seconds time. If not, a retransmit request is sent.
@@ -144,7 +144,7 @@ public class RaopRtpRetransmitRequestHandler extends SimpleChannelUpstreamHandle
 	/**
 	 * Header sequence number for retransmit requests
 	 */
-	private int m_retransmitRequestSequence = 0;
+	private int m_retransmitRequestSequence;
 
 	public RaopRtpRetransmitRequestHandler(final AudioStreamInformationProvider streamInfoProvider, final AudioClock audioClock)
 	{

--- a/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/airreceiver/RtspErrorResponseHandler.java
+++ b/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/airreceiver/RtspErrorResponseHandler.java
@@ -29,7 +29,7 @@ public class RtspErrorResponseHandler extends SimpleChannelHandler
 	/**
 	 * Prevents an infinite loop that otherwise occurs if write()ing the exception response itself triggers an exception (which we will then attempt to write(), triggering the same exception, ...) We avoid that loop by dropping all exception events after the first one.
 	 */
-	private boolean m_messageTriggeredException = false;
+	private boolean m_messageTriggeredException;
 
 	@Override
 	public void messageReceived(final ChannelHandlerContext ctx, final MessageEvent evt) throws Exception

--- a/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/airreceiver/RunningWeightedAverage.java
+++ b/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/airreceiver/RunningWeightedAverage.java
@@ -23,7 +23,7 @@ public class RunningWeightedAverage
 	public final double[] m_values;
 	public final double[] m_weights;
 	public boolean m_empty = true;
-	public int m_index = 0;
+	public int m_index;
 	public double m_average = Double.NaN;
 
 	RunningWeightedAverage(final int windowLength)

--- a/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/audio/JavaSoundSink.java
+++ b/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/audio/JavaSoundSink.java
@@ -76,7 +76,7 @@ public class JavaSoundSink implements SampleClock
 		 */
 		final Latch<Void> endTimeSetLatch = new Latch<Void>(JavaSoundSink.this);
 
-		public volatile boolean exit = false;
+		public volatile boolean exit;
 
 		private volatile double m_lineEndTime;
 

--- a/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/audio/Latch.java
+++ b/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/audio/Latch.java
@@ -20,8 +20,8 @@ package org.dyndns.jkiddo.raop.server.audio;
 public final class Latch<T>
 {
 	private final Object m_monitor;
-	private boolean m_ready = false;
-	private T m_value = null;
+	private boolean m_ready;
+	private T m_value;
 
 	public Latch()
 	{

--- a/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/audio/SampleBuffer.java
+++ b/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/audio/SampleBuffer.java
@@ -27,7 +27,7 @@ public final class SampleBuffer implements SampleIndexedAccessor
 
 	private final SampleIndexer m_samplesIndexer;
 
-	private double m_timeStamp = 0.0;
+	private double m_timeStamp;
 
 	public SampleBuffer(final float[] buffer, final SampleDimensions bufferDimensions, SampleIndexer samplesIndexer)
 	{

--- a/jolivia.jetty/src/main/java/org/dyndns/jkiddo/Jolivia.java
+++ b/jolivia.jetty/src/main/java/org/dyndns/jkiddo/Jolivia.java
@@ -118,7 +118,7 @@ public class Jolivia {
 		};
 		private IPlayingInformation iplayingInformation = new DefaultIPlayingInformation();
 		private PasswordMethod security = PasswordMethod.NO_PASSWORD;
-		private SecurityScheme scheme = null;
+		private SecurityScheme scheme;
 		private String appleUsername;
 		private String applePassword;
 

--- a/jolivia.protocol/src/main/java/org/dyndns/jkiddo/dmp/DmapInputStream.java
+++ b/jolivia.protocol/src/main/java/org/dyndns/jkiddo/dmp/DmapInputStream.java
@@ -55,7 +55,7 @@ public class DmapInputStream extends BufferedInputStream
 
 	private static final Logger logger = LoggerFactory.getLogger(DmapInputStream.class);
 
-	private ChunkFactory factory = null;
+	private ChunkFactory factory;
 
 	private final boolean specialCaseProtocolViolation;
 

--- a/jolivia.protocol/src/main/java/org/dyndns/jkiddo/dmp/chunks/SByteChunk.java
+++ b/jolivia.protocol/src/main/java/org/dyndns/jkiddo/dmp/chunks/SByteChunk.java
@@ -42,7 +42,7 @@ public abstract class SByteChunk extends AbstractChunk implements ByteChunk
 	public static final int MIN_VALUE = Byte.MIN_VALUE;
 	public static final int MAX_VALUE = Byte.MAX_VALUE;
 
-	protected int value = 0;
+	protected int value;
 
 
 	public SByteChunk(final String type, final String name, final int value)

--- a/jolivia.protocol/src/main/java/org/dyndns/jkiddo/dmp/chunks/SIntChunk.java
+++ b/jolivia.protocol/src/main/java/org/dyndns/jkiddo/dmp/chunks/SIntChunk.java
@@ -38,7 +38,7 @@ public abstract class SIntChunk extends AbstractChunk implements IntChunk
 	public static final int MIN_VALUE = Integer.MIN_VALUE;
 	public static final int MAX_VALUE = Integer.MAX_VALUE;
 
-	protected int value = 0;
+	protected int value;
 
 	
 

--- a/jolivia.protocol/src/main/java/org/dyndns/jkiddo/dmp/chunks/SLongChunk.java
+++ b/jolivia.protocol/src/main/java/org/dyndns/jkiddo/dmp/chunks/SLongChunk.java
@@ -38,7 +38,7 @@ public abstract class SLongChunk extends AbstractChunk implements LongChunk
 	public static final long MIN_VALUE = Long.MIN_VALUE;
 	public static final long MAX_VALUE = Long.MAX_VALUE;
 
-	protected long value = 0;
+	protected long value;
 
 	public SLongChunk(final String type, final String name, final long value)
 	{

--- a/jolivia.protocol/src/main/java/org/dyndns/jkiddo/dmp/chunks/SShortChunk.java
+++ b/jolivia.protocol/src/main/java/org/dyndns/jkiddo/dmp/chunks/SShortChunk.java
@@ -42,7 +42,7 @@ public abstract class SShortChunk extends AbstractChunk implements ShortChunk
 	public static final int MIN_VALUE = Short.MIN_VALUE;
 	public static final int MAX_VALUE = Short.MAX_VALUE;
 
-	protected int value = 0;
+	protected int value;
 
 	public SShortChunk(final String type, final String name, final int value)
 	{

--- a/jolivia.protocol/src/main/java/org/dyndns/jkiddo/dmp/chunks/UByteChunk.java
+++ b/jolivia.protocol/src/main/java/org/dyndns/jkiddo/dmp/chunks/UByteChunk.java
@@ -42,7 +42,7 @@ public abstract class UByteChunk extends AbstractChunk implements ByteChunk
 	public static final int MIN_VALUE = 0;
 	public static final int MAX_VALUE = 0xFF;
 
-	protected int value = 0;
+	protected int value;
 
 	public UByteChunk(final String type, final String name, final int value)
 	{

--- a/jolivia.protocol/src/main/java/org/dyndns/jkiddo/dmp/chunks/UIntChunk.java
+++ b/jolivia.protocol/src/main/java/org/dyndns/jkiddo/dmp/chunks/UIntChunk.java
@@ -42,7 +42,7 @@ public abstract class UIntChunk extends AbstractChunk implements IntChunk
 	public static final long MIN_VALUE = 0l;
 	public static final long MAX_VALUE = 0xFFFFFFFFl;
 
-	protected int value = 0;
+	protected int value;
 
 	public UIntChunk(final String type, final String name, final long value)
 	{

--- a/jolivia.protocol/src/main/java/org/dyndns/jkiddo/dmp/chunks/ULongChunk.java
+++ b/jolivia.protocol/src/main/java/org/dyndns/jkiddo/dmp/chunks/ULongChunk.java
@@ -40,7 +40,7 @@ public abstract class ULongChunk extends AbstractChunk implements LongChunk
 	public static final String MIN_VALUE = "0";
 	public static final String MAX_VALUE = "18446744073709551615";
 
-	protected long value = 0;
+	protected long value;
 
 	public ULongChunk(final String type, final String name, final long value)
 	{

--- a/jolivia.protocol/src/main/java/org/dyndns/jkiddo/dmp/chunks/UShortChunk.java
+++ b/jolivia.protocol/src/main/java/org/dyndns/jkiddo/dmp/chunks/UShortChunk.java
@@ -42,7 +42,7 @@ public abstract class UShortChunk extends AbstractChunk implements ShortChunk
 	public static final int MIN_VALUE = 0;
 	public static final int MAX_VALUE = 0xFFFF;
 
-	protected int value = 0;
+	protected int value;
 
 	public UShortChunk(final String type, final String name, final int value)
 	{

--- a/jolivia.protocol/src/main/java/org/dyndns/jkiddo/dmp/chunks/VersionChunk.java
+++ b/jolivia.protocol/src/main/java/org/dyndns/jkiddo/dmp/chunks/VersionChunk.java
@@ -45,7 +45,7 @@ public abstract class VersionChunk extends AbstractChunk
 	public static final long MIN_VALUE = 0l;
 	public static final long MAX_VALUE = 0xFFFFFFFFl;
 
-	protected int version = 0;
+	protected int version;
 
 	public VersionChunk(final String type, final String name, final long value)
 	{


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S3052 - Fields should not be initialized to default values

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S3052

Please let me know if you have any questions.

M-Ezzat