### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/jolivia.airplay/src/main/java/com/beatofthedrum/alacdecoder/AlacDecodeUtils.java
+++ b/jolivia.airplay/src/main/java/com/beatofthedrum/alacdecoder/AlacDecodeUtils.java
@@ -10,8 +10,13 @@
  */
 package com.beatofthedrum.alacdecoder;
 
-public class AlacDecodeUtils
+public final class AlacDecodeUtils
 {
+
+	private AlacDecodeUtils() throws InstantiationException {
+		throw new InstantiationException("This class is not created for instantiation");
+	}
+
 	public static void alac_set_info(AlacFile alac, int[] inputbuffer)
 	{
 		int ptrIndex = 0;

--- a/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/client/DeviceConnectionService.java
+++ b/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/client/DeviceConnectionService.java
@@ -12,9 +12,13 @@ import org.dyndns.jkiddo.raop.client.model.DeviceConnection;
  * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-public class DeviceConnectionService
+public final class DeviceConnectionService
 {
 	private static Map<String, DeviceConnection> deviceConnectionMap = new HashMap<>();
+
+	private DeviceConnectionService() throws InstantiationException {
+		throw new InstantiationException("This class is not created for instantiation");
+	}
 
 	public static DeviceConnection getConnection(Device device)
 	{

--- a/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/airreceiver/Base64.java
+++ b/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/airreceiver/Base64.java
@@ -21,6 +21,11 @@ import java.io.IOException;
 
 public final class Base64
 {
+
+	private Base64() throws InstantiationException {
+		throw new InstantiationException("This class is not created for instantiation");
+	}
+
 	/**
 	 * Decodes Base64 data that is correctly padded with "="
 	 * 

--- a/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/airreceiver/RaopRtspMethods.java
+++ b/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/airreceiver/RaopRtspMethods.java
@@ -34,4 +34,9 @@ public final class RaopRtspMethods
 	public static final HttpMethod SETUP = RtspMethods.SETUP;
 	public static final HttpMethod SET_PARAMETER = RtspMethods.SET_PARAMETER;
 	public static final HttpMethod TEARDOWN = RtspMethods.TEARDOWN;
+
+	private RaopRtspMethods() throws InstantiationException {
+		throw new InstantiationException("This class is not created for instantiation");
+	}
+
 }

--- a/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/audio/Functions.java
+++ b/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/audio/Functions.java
@@ -2,6 +2,10 @@ package org.dyndns.jkiddo.raop.server.audio;
 
 public final class Functions
 {
+	private Functions() throws InstantiationException{
+		throw new InstantiationException("This class is not created for instantiation");
+	}
+
 	public static double sinc(double x)
 	{
 		return Math.sin(x) / x;

--- a/jolivia.dacp/src/main/java/org/dyndns/jkiddo/service/daap/client/RequestHelper.java
+++ b/jolivia.dacp/src/main/java/org/dyndns/jkiddo/service/daap/client/RequestHelper.java
@@ -53,12 +53,16 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.io.Closeables;
 
-public class RequestHelper
+public final class RequestHelper
 {
 	private static final int CONNECT_TIMEOUT = 10000;
 	private static final int READ_TIMEOUT = 0; // Infinite
 
 	public final static Logger logger = LoggerFactory.getLogger(RequestHelper.class);
+
+	private RequestHelper() throws InstantiationException {
+		throw new InstantiationException("This class is not created for instantiation");
+	}
 
 	public static byte[] requestBitmap(final String remote) throws Exception
 	{

--- a/jolivia.example/src/main/java/org/dyndns/jkiddo/JoliviaMainer.java
+++ b/jolivia.example/src/main/java/org/dyndns/jkiddo/JoliviaMainer.java
@@ -20,8 +20,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.bridge.SLF4JBridgeHandler;
 
-public class JoliviaMainer {
+public final class JoliviaMainer {
 	private static Logger logger = LoggerFactory.getLogger(JoliviaMainer.class);
+
+	private JoliviaMainer() throws InstantiationException {
+		throw new InstantiationException("This class is not created for instantiation");
+	}
 
 	public static void main(final String[] args) throws UnknownHostException {
 

--- a/jolivia.protocol/src/main/java/org/dyndns/jkiddo/dmp/tools/PacketAnalyzer.java
+++ b/jolivia.protocol/src/main/java/org/dyndns/jkiddo/dmp/tools/PacketAnalyzer.java
@@ -37,8 +37,12 @@ import org.dyndns.jkiddo.dmp.chunks.AbstractChunk;
 import org.dyndns.jkiddo.dmp.chunks.BooleanChunk;
 import org.dyndns.jkiddo.dmp.chunks.Chunk;
 
-public class PacketAnalyzer
+public final class PacketAnalyzer
 {
+
+	private PacketAnalyzer() throws InstantiationException {
+		throw new InstantiationException("This class is not created for instantiation");
+	}
 
 	private static Chunk newChunk(DmapInputStream in) throws Throwable
 	{

--- a/jolivia.protocol/src/main/java/org/dyndns/jkiddo/dmp/tools/ReflectionsHelper.java
+++ b/jolivia.protocol/src/main/java/org/dyndns/jkiddo/dmp/tools/ReflectionsHelper.java
@@ -20,8 +20,12 @@ import com.google.common.base.Predicates;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableSet;
 
-public class ReflectionsHelper
+public final class ReflectionsHelper
 {
+
+	private ReflectionsHelper() throws InstantiationException {
+		throw new InstantiationException("This class is not created for instantiation");
+	}
 
 	public static ImmutableSet<Class<? extends Object>> getClasses(final String packageName, final Class<? extends Annotation> annotation)
 	{


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat