### PR TITLE
Multiple quality improvements - squid:S1643, squid:S1155, squid:S2864

### DIFF
--- a/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/client/command/DeviceCommand.java
+++ b/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/client/command/DeviceCommand.java
@@ -27,12 +27,14 @@ public abstract class DeviceCommand
 
 	protected String constructCommand(String commandName, String content)
 	{
-		String parameterValue = parameterMap.keySet().size() == 0 ? "" : "?";
-		for(String key : parameterMap.keySet())
+		StringBuilder parameterValue = new StringBuilder();
+		parameterValue.append(parameterMap.isEmpty() ? "" : "?");
+
+		for(Map.Entry<String, String> stringStringEntry : parameterMap.entrySet())
 		{
 			try
 			{
-				parameterValue += key + "=" + URLEncoder.encode(parameterMap.get(key), "utf-8");
+				parameterValue.append(stringStringEntry.getKey()).append("=").append(URLEncoder.encode(stringStringEntry.getValue(), "utf-8"));
 			}
 			catch(UnsupportedEncodingException e)
 			{

--- a/jolivia.dacp/src/main/java/org/dyndns/jkiddo/service/daap/client/RemoteControl.java
+++ b/jolivia.dacp/src/main/java/org/dyndns/jkiddo/service/daap/client/RemoteControl.java
@@ -148,7 +148,7 @@ public class RemoteControl
 	 */
 	public void setSpeakers(final Collection<Speaker> speakers) throws Exception
 	{
-		String idsString = "";
+		StringBuilder idsString = new StringBuilder();
 		boolean first = true;
 		// The list of speakers to activate is a comma-separated string with
 		// the hex versions of the speakers' IDs
@@ -158,13 +158,13 @@ public class RemoteControl
 			{
 				if(!first)
 				{
-					idsString += ",";
+					idsString.append(",");
 				}
 				else
 				{
 					first = false;
 				}
-				idsString += speaker.getIdAsHex();
+				idsString.append(speaker.getIdAsHex());
 			}
 		}
 

--- a/jolivia.protocol/src/main/java/org/dyndns/jkiddo/dmp/chunks/RawChunk.java
+++ b/jolivia.protocol/src/main/java/org/dyndns/jkiddo/dmp/chunks/RawChunk.java
@@ -47,12 +47,12 @@ public abstract class RawChunk extends AbstractChunk
 	@Override
 	public String toString(final int indent)
 	{
-		String val  = "{";
+		StringBuilder val  = new StringBuilder("{");
 		for(int i = 0; i < value.length - 1; i++)
 		{
-			val += (int)value[i] + ", ";
+			val.append((int)value[i]).append(", ");
 		}
-		val += (int)value[value.length - 1] + "}";
+		val.append((int)value[value.length - 1]).append("}");
 		return indent(indent) + name + "(" + getContentCodeString() + "; raw)=" + val;
 	}
 	


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:S1643 - Strings should not be concatenated using '+' in a loop
squid:S1155 - Collection.isEmpty() should be used to test for emptiness
squid:S2864 - "entrySet()" should be iterated when both the key and value are needed


You can find more information about the issues here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1643
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1155
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2864

Please let me know if you have any questions.

M-Ezzat