### PR TITLE
Cleanup - squid:S2142 - InterruptedException should not be ignored

### DIFF
--- a/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/audio/JavaSoundSink.java
+++ b/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/audio/JavaSoundSink.java
@@ -115,6 +115,7 @@ public class JavaSoundSink implements SampleClock
 								catch(InterruptedException e)
 								{
 									s_logger.log(Level.WARNING, "Java Sound line writer was interrupted during startup", e);
+                                    Thread.currentThread().interrupt();
 									throw new RuntimeException(e.getMessage(), e);
 								}
 
@@ -259,7 +260,7 @@ public class JavaSoundSink implements SampleClock
 			}
 			catch(InterruptedException e)
 			{
-				/* Done */
+                Thread.currentThread().interrupt();
 			}
 		}
 

--- a/jolivia.daap/src/main/java/org/dyndns/jkiddo/service/daap/server/InMemoryMusicManager.java
+++ b/jolivia.daap/src/main/java/org/dyndns/jkiddo/service/daap/server/InMemoryMusicManager.java
@@ -167,6 +167,7 @@ public class InMemoryMusicManager implements IItemManager
 		catch(final InterruptedException ie)
 		{
 			ie.printStackTrace();
+            Thread.currentThread().interrupt();
 		}
 	}
 

--- a/jolivia.daap/src/main/java/org/dyndns/jkiddo/service/daap/server/MusicItemManager.java
+++ b/jolivia.daap/src/main/java/org/dyndns/jkiddo/service/daap/server/MusicItemManager.java
@@ -159,6 +159,7 @@ public class MusicItemManager implements IItemManager
 		catch(final InterruptedException ie)
 		{
 			ie.printStackTrace();
+            Thread.currentThread().interrupt();
 		}
 	}
 

--- a/jolivia.dacp/src/main/java/org/dyndns/jkiddo/service/dacp/server/TouchAbleServerResource.java
+++ b/jolivia.dacp/src/main/java/org/dyndns/jkiddo/service/dacp/server/TouchAbleServerResource.java
@@ -195,6 +195,7 @@ public class TouchAbleServerResource extends MDNSResource implements ITouchAbleS
 			{
 				// TODO Auto-generated catch block
 				e.printStackTrace();
+                Thread.currentThread().interrupt();
 			}
 		}
 		final PlayingStatus response = new PlayingStatus();

--- a/jolivia.dpap/src/main/java/org/dyndns/jkiddo/service/dpap/server/ImageItemManager.java
+++ b/jolivia.dpap/src/main/java/org/dyndns/jkiddo/service/dpap/server/ImageItemManager.java
@@ -89,6 +89,7 @@ public class ImageItemManager implements IItemManager
 		catch(InterruptedException ie)
 		{
 			ie.printStackTrace();
+            Thread.currentThread().interrupt();
 		}
 	}
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2142 - "InterruptedException" should not be ignored

You can find more information about the issue here: https://sonarqube.com/coding_rules#rule_key=squid:S2142

Please let me know if you have any questions.

M-Ezzat