### PR TITLE
squid:S3398 - private methods called only by inner classes should be …

### DIFF
--- a/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/audio/JavaSoundSink.java
+++ b/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/audio/JavaSoundSink.java
@@ -312,6 +312,19 @@ public class JavaSoundSink implements SampleClock
 		{
 			return m_lineEndTime;
 		}
+
+        private synchronized void mute()
+        {
+            if(m_currentGain > Float.MIN_VALUE)
+                setJavaSoundLineGain(Float.MIN_VALUE);
+        }
+
+        private synchronized void unmute()
+        {
+            if(m_currentGain == Float.MIN_VALUE)
+                setJavaSoundLineGain(m_requestedGain);
+        }
+
 	}
 
 	public JavaSoundSink(final double sampleRate, int channels, SampleSource sampleSource) throws InterruptedException
@@ -426,15 +439,4 @@ public class JavaSoundSink implements SampleClock
 		m_currentGain = gain;
 	}
 
-	private synchronized void mute()
-	{
-		if(m_currentGain > Float.MIN_VALUE)
-			setJavaSoundLineGain(Float.MIN_VALUE);
-	}
-
-	private synchronized void unmute()
-	{
-		if(m_currentGain == Float.MIN_VALUE)
-			setJavaSoundLineGain(m_requestedGain);
-	}
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S3398 - "private" methods called only by inner classes should be moved to those classes

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S3398

Please let me know if you have any questions.

M-Ezzat