### PR TITLE
Cleanup - squid:S1312 - Loggers should be "private static final" and …

### DIFF
--- a/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/client/JettyCommandService.java
+++ b/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/client/JettyCommandService.java
@@ -32,7 +32,7 @@ import com.google.gson.Gson;
 
 public class JettyCommandService extends AbstractHandler
 {
-	private static Logger logger = Logger.getLogger(JettyCommandService.class.getName());
+	private static final Logger LOGGER = Logger.getLogger(JettyCommandService.class.getName());
 
 	private static Map<String, Device> deviceMap = new HashMap<>();
 
@@ -87,7 +87,7 @@ public class JettyCommandService extends AbstractHandler
 			}
 			catch(RuntimeException e)
 			{
-				logger.log(Level.SEVERE, e.getMessage(), e);
+				LOGGER.log(Level.SEVERE, e.getMessage(), e);
 			}
 		}
 	}
@@ -126,7 +126,7 @@ public class JettyCommandService extends AbstractHandler
 				Device device = deviceMap.get(deviceId);
 				if(device == null)
 				{
-					logger.log(Level.SEVERE, "Device ID is not valid: " + deviceId);
+					LOGGER.log(Level.SEVERE, "Device ID is not valid: " + deviceId);
 					sendErrorResponse(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Device ID is not valid: " + deviceId, baseRequest, response);
 				}
 				else
@@ -186,7 +186,7 @@ public class JettyCommandService extends AbstractHandler
 				}
 				else
 				{
-					logger.log(Level.INFO, "Error response: code=" + deviceResponse.getResponseCode() + " message=" + deviceResponse.getResponseMessage());
+					LOGGER.log(Level.INFO, "Error response: code=" + deviceResponse.getResponseCode() + " message=" + deviceResponse.getResponseMessage());
 					sendErrorResponse(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, deviceResponse.getResponseMessage(), baseRequest, response);
 				}
 			}
@@ -203,7 +203,7 @@ public class JettyCommandService extends AbstractHandler
 				}
 				catch(NumberFormatException e)
 				{
-					logger.log(Level.INFO, "Could not parse rate parameter: " + request.getParameter("r"));
+					LOGGER.log(Level.INFO, "Could not parse rate parameter: " + request.getParameter("r"));
 					sendErrorResponse(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Rate is not valid.", baseRequest, response);
 				}
 
@@ -238,7 +238,7 @@ public class JettyCommandService extends AbstractHandler
 				}
 				catch(NumberFormatException e)
 				{
-					logger.log(Level.INFO, "Could not parse position parameter: " + request.getParameter("p"));
+					LOGGER.log(Level.INFO, "Could not parse position parameter: " + request.getParameter("p"));
 					sendErrorResponse(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Position is not valid.", baseRequest, response);
 				}
 
@@ -261,7 +261,7 @@ public class JettyCommandService extends AbstractHandler
 					}
 					else
 					{
-						logger.log(Level.INFO, "Error response: code=" + deviceResponse.getResponseCode() + " message=" + deviceResponse.getResponseMessage());
+						LOGGER.log(Level.INFO, "Error response: code=" + deviceResponse.getResponseCode() + " message=" + deviceResponse.getResponseMessage());
 						sendErrorResponse(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, deviceResponse.getResponseMessage(), baseRequest, response);
 					}
 				}
@@ -269,7 +269,7 @@ public class JettyCommandService extends AbstractHandler
 				break;
 			default:
 			{
-				logger.info("Command not understood: " + request.getParameter("t"));
+				LOGGER.info("Command not understood: " + request.getParameter("t"));
 				sendErrorResponse(HttpServletResponse.SC_NOT_ACCEPTABLE, "Command not understood.", baseRequest, response);
 			}
 		}

--- a/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/client/RemoteSpeakerDiscoverer.java
+++ b/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/client/RemoteSpeakerDiscoverer.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
 @Singleton
 public class RemoteSpeakerDiscoverer implements IDiscoverer
 {
-	public static final Logger logger = LoggerFactory.getLogger(RemoteSpeakerDiscoverer.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(RemoteSpeakerDiscoverer.class);
 
 	private final JmmDNS mDNS;
 	private final Map<JmDNS, InetAddress> interfaces = new HashMap<JmDNS, InetAddress>();
@@ -48,13 +48,13 @@ public class RemoteSpeakerDiscoverer implements IDiscoverer
 	@Override
 	public void serviceAdded(ServiceEvent event)
 	{
-		logger.info("ADD: " + event.getDNS().getServiceInfo(event.getType(), event.getName()));
+		LOGGER.info("ADD: " + event.getDNS().getServiceInfo(event.getType(), event.getName()));
 	}
 
 	@Override
 	public void serviceRemoved(ServiceEvent event)
 	{
-		logger.debug("REMOVE: " + event.getName());
+		LOGGER.debug("REMOVE: " + event.getName());
 		this.speakerListener.removeAvailableSpeaker(event.getInfo().getServer(), event.getInfo().getPort());
 	}
 
@@ -62,7 +62,7 @@ public class RemoteSpeakerDiscoverer implements IDiscoverer
 	@Override
 	public void serviceResolved(ServiceEvent event)
 	{
-		logger.info("ADD: " + event.getDNS().getServiceInfo(event.getType(), event.getName()));
+		LOGGER.info("ADD: " + event.getDNS().getServiceInfo(event.getType(), event.getName()));
 		speakerListener.registerAvailableSpeaker(DeviceConnectionService.getConnection(new Device(event.getName(), event.getInfo().getInetAddress(), event.getInfo().getPort())));
 	}
 
@@ -71,7 +71,7 @@ public class RemoteSpeakerDiscoverer implements IDiscoverer
 	{
 		JmDNS mdns = event.getDNS();
 		InetAddress address = event.getInetAddress();
-		logger.info("Registered RemoteSpeakerDiscoverer @ " + address.getHostAddress());
+		LOGGER.info("Registered RemoteSpeakerDiscoverer @ " + address.getHostAddress());
 		mdns.addServiceListener(ISpeakerListener.RAOP_TYPE, this);
 		interfaces.put(mdns, address);
 	}

--- a/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/client/command/DeviceCommand.java
+++ b/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/client/command/DeviceCommand.java
@@ -14,7 +14,7 @@ import java.io.UnsupportedEncodingException;
 
 public abstract class DeviceCommand
 {
-	private static Logger logger = Logger.getLogger(DeviceCommand.class.getName());
+	private static final Logger LOGGER = Logger.getLogger(DeviceCommand.class.getName());
 
 	private final Map<String, String> parameterMap = new HashMap<>();
 
@@ -38,7 +38,7 @@ public abstract class DeviceCommand
 			}
 			catch(UnsupportedEncodingException e)
 			{
-				logger.log(Level.SEVERE, e.getMessage(), e);
+				LOGGER.log(Level.SEVERE, e.getMessage(), e);
 				throw new RuntimeException(e.getMessage(), e);
 			}
 		}

--- a/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/client/model/DeviceConnection.java
+++ b/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/client/model/DeviceConnection.java
@@ -14,7 +14,7 @@ import org.dyndns.jkiddo.raop.client.command.DeviceCommand;
  */
 public class DeviceConnection
 {
-	private static Logger logger = Logger.getLogger(DeviceConnection.class.getName());
+	private static final Logger LOGGER = Logger.getLogger(DeviceConnection.class.getName());
 
 	private final Device device;
 	private Socket socket;
@@ -49,7 +49,7 @@ public class DeviceConnection
 			}
 			catch(IOException e)
 			{
-				logger.log(Level.SEVERE, e.getMessage(), e);
+				LOGGER.log(Level.SEVERE, e.getMessage(), e);
 				throw new RuntimeException(e.getMessage(), e);
 			}
 		}
@@ -99,7 +99,7 @@ public class DeviceConnection
 		}
 		catch(IOException e)
 		{
-			logger.log(Level.SEVERE, e.getMessage(), e);
+			LOGGER.log(Level.SEVERE, e.getMessage(), e);
 			throw new RuntimeException(e.getMessage(), e);
 		}
 	}

--- a/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/airreceiver/AirTunesCrytography.java
+++ b/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/airreceiver/AirTunesCrytography.java
@@ -32,7 +32,7 @@ import javax.crypto.CipherSpi;
 
 public final class AirTunesCrytography
 {
-	private static final Logger s_logger = Logger.getLogger(AirTunesCrytography.class.getName());
+	private static final Logger LOGGER = Logger.getLogger(AirTunesCrytography.class.getName());
 
 	/**
 	 * The JCA/JCE Provider who supplies the necessary cryptographic algorithms
@@ -132,7 +132,7 @@ public final class AirTunesCrytography
 
 			/* Create a {@link javax.crypto.Cipher} instance from the {@link javax.crypto.CipherSpi} the provider gave us */
 
-			s_logger.info("Using SPI " + cipherSpi.getClass() + " for " + transformation);
+			LOGGER.info("Using SPI " + cipherSpi.getClass() + " for " + transformation);
 			return getCipher(cipherSpi, transformation.toUpperCase());
 		}
 		catch(final RuntimeException e)

--- a/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/airreceiver/ExceptionLoggingHandler.java
+++ b/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/airreceiver/ExceptionLoggingHandler.java
@@ -27,12 +27,12 @@ import org.jboss.netty.channel.*;
  */
 public class ExceptionLoggingHandler extends SimpleChannelHandler
 {
-	private static Logger s_logger = Logger.getLogger(ExceptionLoggingHandler.class.getName());
+	private static final Logger LOGGER = Logger.getLogger(ExceptionLoggingHandler.class.getName());
 
 	@Override
 	public void exceptionCaught(final ChannelHandlerContext ctx, final ExceptionEvent evt) throws Exception
 	{
 		super.exceptionCaught(ctx, evt);
-		s_logger.log(Level.WARNING, "Handler raised exception", evt.getCause());
+		LOGGER.log(Level.WARNING, "Handler raised exception", evt.getCause());
 	}
 }

--- a/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/airreceiver/RaopAudioHandler.java
+++ b/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/airreceiver/RaopAudioHandler.java
@@ -75,7 +75,7 @@ import org.slf4j.LoggerFactory;
  */
 public class RaopAudioHandler extends SimpleChannelUpstreamHandler
 {
-	private static Logger logger = LoggerFactory.getLogger(RaopAudioHandler.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(RaopAudioHandler.class.getName());
 
 	/**
 	 * {@code Transport} header option format. Format of a single option is <br>
@@ -234,12 +234,12 @@ public class RaopAudioHandler extends SimpleChannelUpstreamHandler
 				final byte[] samples = new byte[audioPacket.getPayload().capacity()];
 				audioPacket.getPayload().getBytes(0, samples);
 				m_audioOutputQueue.enqueue(audioPacket.getTimeStamp(), samples);
-				if(logger.isTraceEnabled())
-					logger.trace("Packet with sequence " + audioPacket.getSequence() + " for playback at " + audioPacket.getTimeStamp() + " submitted to audio output queue");
+				if(LOGGER.isTraceEnabled())
+					LOGGER.trace("Packet with sequence " + audioPacket.getSequence() + " for playback at " + audioPacket.getTimeStamp() + " submitted to audio output queue");
 			}
 			else
 			{
-				logger.warn("No audio queue available, dropping packet");
+				LOGGER.warn("No audio queue available, dropping packet");
 			}
 
 			super.messageReceived(ctx, evt);
@@ -322,7 +322,7 @@ public class RaopAudioHandler extends SimpleChannelUpstreamHandler
 	@Override
 	public void channelClosed(final ChannelHandlerContext ctx, final ChannelStateEvent evt) throws Exception
 	{
-		logger.info("RTSP connection was shut down, closing RTP channels and audio output queue");
+		LOGGER.info("RTSP connection was shut down, closing RTP channels and audio output queue");
 
 		synchronized(this)
 		{
@@ -474,7 +474,7 @@ public class RaopAudioHandler extends SimpleChannelUpstreamHandler
 					}
 					else
 					{
-						logger.info("Key " + key + " was unmapped");
+						LOGGER.info("Key " + key + " was unmapped");
 					}
 					break;
 
@@ -568,7 +568,7 @@ public class RaopAudioHandler extends SimpleChannelUpstreamHandler
 				/* Port number of the client's control socket. Response includes port number of *our* control port */
 				final int clientControlPort = Integer.parseInt(value);
 				m_controlChannel = createRtpChannel(substitutePort((InetSocketAddress) ctx.getChannel().getLocalAddress(), 0), substitutePort((InetSocketAddress) ctx.getChannel().getRemoteAddress(), clientControlPort), RaopRtpChannelType.Control);
-				logger.info("Launched RTP control service on " + m_controlChannel.getLocalAddress());
+				LOGGER.info("Launched RTP control service on " + m_controlChannel.getLocalAddress());
 				responseOptions.add("control_port=" + ((InetSocketAddress) m_controlChannel.getLocalAddress()).getPort());
 			}
 			else if("timing_port".equals(key))
@@ -576,7 +576,7 @@ public class RaopAudioHandler extends SimpleChannelUpstreamHandler
 				/* Port number of the client's timing socket. Response includes port number of *our* timing port */
 				final int clientTimingPort = Integer.parseInt(value);
 				m_timingChannel = createRtpChannel(substitutePort((InetSocketAddress) ctx.getChannel().getLocalAddress(), 0), substitutePort((InetSocketAddress) ctx.getChannel().getRemoteAddress(), clientTimingPort), RaopRtpChannelType.Timing);
-				logger.info("Launched RTP timing service on " + m_timingChannel.getLocalAddress());
+				LOGGER.info("Launched RTP timing service on " + m_timingChannel.getLocalAddress());
 				responseOptions.add("timing_port=" + ((InetSocketAddress) m_timingChannel.getLocalAddress()).getPort());
 			}
 			else
@@ -588,7 +588,7 @@ public class RaopAudioHandler extends SimpleChannelUpstreamHandler
 
 		/* Create audio socket and include it's port in our response */
 		m_audioChannel = createRtpChannel(substitutePort((InetSocketAddress) ctx.getChannel().getLocalAddress(), 0), null, RaopRtpChannelType.Audio);
-		logger.info("Launched RTP audio service on " + m_audioChannel.getLocalAddress());
+		LOGGER.info("Launched RTP audio service on " + m_audioChannel.getLocalAddress());
 		responseOptions.add("server_port=" + ((InetSocketAddress) m_audioChannel.getLocalAddress()).getPort());
 
 		/* Build response options string */
@@ -615,7 +615,7 @@ public class RaopAudioHandler extends SimpleChannelUpstreamHandler
 		if(m_audioStreamInformationProvider == null)
 			throw new ProtocolException("Audio stream not configured, cannot start recording");
 
-		logger.info("Client started streaming");
+		LOGGER.info("Client started streaming");
 
 		final HttpResponse response = new DefaultHttpResponse(RtspVersions.RTSP_1_0, RtspResponseStatuses.OK);
 		ctx.getChannel().write(response);
@@ -629,7 +629,7 @@ public class RaopAudioHandler extends SimpleChannelUpstreamHandler
 		if(m_audioOutputQueue != null)
 			m_audioOutputQueue.flush();
 
-		logger.info("Client paused streaming, flushed audio output queue");
+		LOGGER.info("Client paused streaming, flushed audio output queue");
 
 		final HttpResponse response = new DefaultHttpResponse(RtspVersions.RTSP_1_0, RtspResponseStatuses.OK);
 		ctx.getChannel().write(response);
@@ -647,7 +647,7 @@ public class RaopAudioHandler extends SimpleChannelUpstreamHandler
 			public void operationComplete(final ChannelFuture future) throws Exception
 			{
 				future.getChannel().close();
-				logger.info("RTSP connection closed after client initiated teardown");
+				LOGGER.info("RTSP connection closed after client initiated teardown");
 			}
 		});
 	}
@@ -667,7 +667,7 @@ public class RaopAudioHandler extends SimpleChannelUpstreamHandler
 			}
 			catch(final IOException e)
 			{
-				logger.debug(e.getMessage(), e);
+				LOGGER.debug(e.getMessage(), e);
 			}
 		}
 		else if(req.headers().get(HttpHeaders.CONTENT_TYPE) != null && req.headers().get(HttpHeaders.CONTENT_TYPE).equalsIgnoreCase(Util.APPLICATION_X_DMAP_TAGGED))
@@ -722,7 +722,7 @@ public class RaopAudioHandler extends SimpleChannelUpstreamHandler
 		}
 		else
 		{
-			logger.warn("Unknown content type: " + req.headers().get(HttpHeaders.CONTENT_TYPE));
+			LOGGER.warn("Unknown content type: " + req.headers().get(HttpHeaders.CONTENT_TYPE));
 		}
 		final HttpResponse response = new DefaultHttpResponse(RtspVersions.RTSP_1_0, RtspResponseStatuses.OK);
 		ctx.getChannel().write(response);

--- a/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/airreceiver/RaopRtpAudioAlacDecodeHandler.java
+++ b/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/airreceiver/RaopRtpAudioAlacDecodeHandler.java
@@ -32,7 +32,7 @@ import com.beatofthedrum.alacdecoder.*;
  */
 public class RaopRtpAudioAlacDecodeHandler extends OneToOneDecoder implements AudioStreamInformationProvider
 {
-	private static Logger s_logger = Logger.getLogger(RaopRtpAudioAlacDecodeHandler.class.getName());
+	private static final Logger LOGGER = Logger.getLogger(RaopRtpAudioAlacDecodeHandler.class.getName());
 
 	/*
 	 * There are the indices into the SDP format options at which the sessions appear
@@ -101,7 +101,7 @@ public class RaopRtpAudioAlacDecodeHandler extends OneToOneDecoder implements Au
 		m_alacFile.setinfo_86 = Integer.valueOf(formatOptions[FormatOption86]);
 		m_alacFile.setinfo_8a_rate = sampleRate;
 
-		s_logger.info("Created ALAC decode for options " + Arrays.toString(formatOptions));
+		LOGGER.info("Created ALAC decode for options " + Arrays.toString(formatOptions));
 	}
 
 	@Override
@@ -125,8 +125,8 @@ public class RaopRtpAudioAlacDecodeHandler extends OneToOneDecoder implements Au
 		/* decode_frame() returns the number of *bytes*, not samples! */
 		final int pcmSamplesLength = pcmSamplesBytes / 4;
 		final Level level = Level.FINEST;
-		if(s_logger.isLoggable(level))
-			s_logger.log(level, "Decoded " + alacBytes.length + " bytes of ALAC audio data to " + pcmSamplesLength + " PCM samples");
+		if(LOGGER.isLoggable(level))
+			LOGGER.log(level, "Decoded " + alacBytes.length + " bytes of ALAC audio data to " + pcmSamplesLength + " PCM samples");
 
 		/* Complain if the sender doesn't honour it's commitment */
 		if(pcmSamplesLength != m_samplesPerFrame)

--- a/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/airreceiver/RaopRtpDecodeHandler.java
+++ b/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/airreceiver/RaopRtpDecodeHandler.java
@@ -28,7 +28,7 @@ import org.jboss.netty.handler.codec.oneone.OneToOneDecoder;
  */
 public class RaopRtpDecodeHandler extends OneToOneDecoder
 {
-	private static final Logger s_logger = Logger.getLogger(RaopRtpDecodeHandler.class.getName());
+	private static final Logger LOGGER = Logger.getLogger(RaopRtpDecodeHandler.class.getName());
 
 	@Override
 	protected Object decode(final ChannelHandlerContext ctx, final Channel channel, final Object msg) throws Exception
@@ -43,7 +43,7 @@ public class RaopRtpDecodeHandler extends OneToOneDecoder
 			}
 			catch(final InvalidPacketException e1)
 			{
-				s_logger.warning(e1.getMessage());
+				LOGGER.warning(e1.getMessage());
 				return buffer;
 			}
 		}

--- a/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/airreceiver/RaopRtpRetransmitRequestHandler.java
+++ b/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/airreceiver/RaopRtpRetransmitRequestHandler.java
@@ -34,7 +34,7 @@ import org.jboss.netty.channel.SimpleChannelUpstreamHandler;
  */
 public class RaopRtpRetransmitRequestHandler extends SimpleChannelUpstreamHandler
 {
-	private static Logger s_logger = Logger.getLogger(RaopRtpRetransmitRequestHandler.class.getName());
+	private static final Logger LOGGER = Logger.getLogger(RaopRtpRetransmitRequestHandler.class.getName());
 
 	/**
 	 * Maximal number of in-flight (i.e. not yet fulfilled) retransmit requests
@@ -168,7 +168,7 @@ public class RaopRtpRetransmitRequestHandler extends SimpleChannelUpstreamHandle
 			final MissingPacket missingPacket = i.next();
 			if(missingPacket.sequence == sequence)
 			{
-				s_logger.fine("Packet " + sequence + " arrived " + (missingPacket.expectedUntilSecondsTime - nextSecondsTimee) + " seconds before it was due");
+				LOGGER.fine("Packet " + sequence + " arrived " + (missingPacket.expectedUntilSecondsTime - nextSecondsTimee) + " seconds before it was due");
 				i.remove();
 			}
 		}
@@ -188,13 +188,13 @@ public class RaopRtpRetransmitRequestHandler extends SimpleChannelUpstreamHandle
 		final MissingPacket missingPacket = new MissingPacket(sequence, nextSecondsTime);
 		if(missingPacket.requiredUntilSecondsTime > nextSecondsTime)
 		{
-			s_logger.fine("Packet " + sequence + " expected to arive in " + (missingPacket.expectedUntilSecondsTime - nextSecondsTime) + " seconds");
+			LOGGER.fine("Packet " + sequence + " expected to arive in " + (missingPacket.expectedUntilSecondsTime - nextSecondsTime) + " seconds");
 
 			m_missingPackets.add(missingPacket);
 		}
 		else
 		{
-			s_logger.warning("Packet " + sequence + " was required " + (nextSecondsTime - missingPacket.expectedUntilSecondsTime) + " seconds ago, not requesting retransmit");
+			LOGGER.warning("Packet " + sequence + " was required " + (nextSecondsTime - missingPacket.expectedUntilSecondsTime) + " seconds ago, not requesting retransmit");
 		}
 
 		/*
@@ -205,7 +205,7 @@ public class RaopRtpRetransmitRequestHandler extends SimpleChannelUpstreamHandle
 			final MissingPacket m = m_missingPackets.get(0);
 			m_missingPackets.remove(0);
 
-			s_logger.warning("Packet " + sequence + " overflowed in-flight retransmit count, giving up on old packet " + m.sequence);
+			LOGGER.warning("Packet " + sequence + " overflowed in-flight retransmit count, giving up on old packet " + m.sequence);
 		}
 	}
 
@@ -232,7 +232,7 @@ public class RaopRtpRetransmitRequestHandler extends SimpleChannelUpstreamHandle
 			 */
 			if(missingPacket.requiredUntilSecondsTime <= nextSecondsTime)
 			{
-				s_logger.warning("Packet " + missingPacket.sequence + " was required " + (nextSecondsTime - missingPacket.requiredUntilSecondsTime) + " secons ago, giving up");
+				LOGGER.warning("Packet " + missingPacket.sequence + " was required " + (nextSecondsTime - missingPacket.requiredUntilSecondsTime) + " secons ago, giving up");
 
 				missingPacketIterator.remove();
 				continue;
@@ -251,7 +251,7 @@ public class RaopRtpRetransmitRequestHandler extends SimpleChannelUpstreamHandle
 				/*
 				 * If the packet was already requests too often, warn and forget about it
 				 */
-				s_logger.warning("Packet " + missingPacket.sequence + " overdue " + (nextSecondsTime - missingPacket.expectedUntilSecondsTime) + " seconds after " + missingPacket.retransmitRequestCount + " retransmit requests, giving up");
+				LOGGER.warning("Packet " + missingPacket.sequence + " overdue " + (nextSecondsTime - missingPacket.expectedUntilSecondsTime) + " seconds after " + missingPacket.retransmitRequestCount + " retransmit requests, giving up");
 
 				missingPacketIterator.remove();
 				continue;
@@ -261,7 +261,7 @@ public class RaopRtpRetransmitRequestHandler extends SimpleChannelUpstreamHandle
 			final double expectedUntilSecondsTimePrevious = missingPacket.expectedUntilSecondsTime;
 			missingPacket.sentRetransmitRequest(nextSecondsTime);
 
-			s_logger.fine("Packet " + missingPacket.sequence + " overdue " + (nextSecondsTime - expectedUntilSecondsTimePrevious) + " seconds after " + retransmitRequestCountPrevious + " retransmit requests, requesting again expecting response in " + (missingPacket.expectedUntilSecondsTime - nextSecondsTime) + " seconds");
+			LOGGER.fine("Packet " + missingPacket.sequence + " overdue " + (nextSecondsTime - expectedUntilSecondsTimePrevious) + " seconds after " + retransmitRequestCountPrevious + " retransmit requests, requesting again expecting response in " + (missingPacket.expectedUntilSecondsTime - nextSecondsTime) + " seconds");
 
 			/* Ok, really request re-transmission */
 
@@ -353,7 +353,7 @@ public class RaopRtpRetransmitRequestHandler extends SimpleChannelUpstreamHandle
 		else if((delta > 1) && (delta <= RetransmitInFlightLimit))
 		{
 			/* Previous packet reordered/delayed or missing */
-			s_logger.fine("Packet sequence number increased by " + delta + ", " + (delta - 1) + " packet(s) missing,");
+			LOGGER.fine("Packet sequence number increased by " + delta + ", " + (delta - 1) + " packet(s) missing,");
 
 			for(int s = expectedSequence; s != audioPacket.getSequence(); s = sequenceSuccessor(s))
 				markMissing(s, nextSecondsTime);
@@ -361,12 +361,12 @@ public class RaopRtpRetransmitRequestHandler extends SimpleChannelUpstreamHandle
 		else if(delta < 0)
 		{
 			/* Delayed packet */
-			s_logger.fine("Packet sequence number decreased by " + (-delta) + ", assuming delayed packet");
+			LOGGER.fine("Packet sequence number decreased by " + (-delta) + ", assuming delayed packet");
 		}
 		else
 		{
 			/* Unsynchronized sequences */
-			s_logger.warning("Packet sequence number jumped to " + audioPacket.getSequence() + ", assuming sequences number are out of sync");
+			LOGGER.warning("Packet sequence number jumped to " + audioPacket.getSequence() + ", assuming sequences number are out of sync");
 
 			m_missingPackets.clear();
 		}

--- a/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/airreceiver/RaopRtpTimingHandler.java
+++ b/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/airreceiver/RaopRtpTimingHandler.java
@@ -28,7 +28,7 @@ import org.jboss.netty.channel.*;
  */
 public class RaopRtpTimingHandler extends SimpleChannelHandler
 {
-	private static Logger s_logger = Logger.getLogger(RaopRtpTimingHandler.class.getName());
+	private static final Logger LOGGER = Logger.getLogger(RaopRtpTimingHandler.class.getName());
 
 	/**
 	 * Number of seconds between {@link TimingRequest}s.
@@ -102,7 +102,7 @@ public class RaopRtpTimingHandler extends SimpleChannelHandler
 			m_synchronizationThread.setDaemon(true);
 			m_synchronizationThread.setName("Time Synchronizer");
 			m_synchronizationThread.start();
-			s_logger.fine("Time synchronizer started");
+			LOGGER.fine("Time synchronizer started");
 		}
 
 		super.channelOpen(ctx, evt);
@@ -153,7 +153,7 @@ public class RaopRtpTimingHandler extends SimpleChannelHandler
 		m_remoteSecondsOffset.add(remoteSecondsOffset, weight);
 		final double secondsTimeAdjustment = m_remoteSecondsOffset.get() - remoteSecondsOffsetPrevious;
 
-		s_logger.finest("Timing response with weight " + weight + " indicated offset " + remoteSecondsOffset + " thereby adjusting the averaged offset by " + secondsTimeAdjustment + " leading to the new averaged offset " + m_remoteSecondsOffset.get());
+		LOGGER.finest("Timing response with weight " + weight + " indicated offset " + remoteSecondsOffset + " thereby adjusting the averaged offset by " + secondsTimeAdjustment + " leading to the new averaged offset " + m_remoteSecondsOffset.get());
 	}
 
 	private synchronized void syncReceived(final RaopRtpPacket.Sync syncPacket)
@@ -171,7 +171,7 @@ public class RaopRtpTimingHandler extends SimpleChannelHandler
 			 * If the times aren't yet synchronized, we simply assume the sync packet's transmission time is zero.
 			 */
 			m_audioClock.setFrameTime(syncPacket.getTimeStampMinusLatency(), 0.0);
-			s_logger.warning("Times synchronized, cannot correct latency of sync packet");
+			LOGGER.warning("Times synchronized, cannot correct latency of sync packet");
 		}
 	}
 

--- a/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/airreceiver/RtpLoggingHandler.java
+++ b/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/airreceiver/RtpLoggingHandler.java
@@ -29,7 +29,7 @@ import org.jboss.netty.channel.SimpleChannelHandler;
  */
 public class RtpLoggingHandler extends SimpleChannelHandler
 {
-	private static final Logger s_logger = Logger.getLogger(RtpLoggingHandler.class.getName());
+	private static final Logger LOGGER = Logger.getLogger(RtpLoggingHandler.class.getName());
 
 	@Override
 	public void messageReceived(final ChannelHandlerContext ctx, final MessageEvent evt) throws Exception
@@ -39,8 +39,8 @@ public class RtpLoggingHandler extends SimpleChannelHandler
 			final RtpPacket packet = (RtpPacket) evt.getMessage();
 
 			final Level level = getPacketLevel(packet);
-			if(s_logger.isLoggable(level))
-				s_logger.log(level, evt.getRemoteAddress() + "> " + packet.toString());
+			if(LOGGER.isLoggable(level))
+				LOGGER.log(level, evt.getRemoteAddress() + "> " + packet.toString());
 		}
 
 		super.messageReceived(ctx, evt);
@@ -54,8 +54,8 @@ public class RtpLoggingHandler extends SimpleChannelHandler
 			final RtpPacket packet = (RtpPacket) evt.getMessage();
 
 			final Level level = getPacketLevel(packet);
-			if(s_logger.isLoggable(level))
-				s_logger.log(level, evt.getRemoteAddress() + "< " + packet.toString());
+			if(LOGGER.isLoggable(level))
+				LOGGER.log(level, evt.getRemoteAddress() + "< " + packet.toString());
 		}
 
 		super.writeRequested(ctx, evt);

--- a/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/airreceiver/RtspLoggingHandler.java
+++ b/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/airreceiver/RtspLoggingHandler.java
@@ -34,12 +34,12 @@ import org.jboss.netty.handler.codec.http.HttpResponse;
  */
 public class RtspLoggingHandler extends SimpleChannelHandler
 {
-	private static final Logger s_logger = Logger.getLogger(RtspLoggingHandler.class.getName());
+	private static final Logger LOGGER = Logger.getLogger(RtspLoggingHandler.class.getName());
 
 	@Override
 	public void channelConnected(final ChannelHandlerContext ctx, final ChannelStateEvent e) throws Exception
 	{
-		s_logger.info("Client " + e.getChannel().getRemoteAddress() + " connected on " + e.getChannel().getLocalAddress());
+		LOGGER.info("Client " + e.getChannel().getRemoteAddress() + " connected on " + e.getChannel().getLocalAddress());
 	}
 
 	@Override
@@ -50,7 +50,7 @@ public class RtspLoggingHandler extends SimpleChannelHandler
 			final HttpRequest req = (HttpRequest) evt.getMessage();
 
 			final Level level = Level.FINE;
-			if(s_logger.isLoggable(level))
+			if(LOGGER.isLoggable(level))
 			{
 				final String content = req.getContent().toString(Charset.defaultCharset());
 
@@ -69,7 +69,7 @@ public class RtspLoggingHandler extends SimpleChannelHandler
 					s.append("\n");
 				}
 				s.append(content);
-				s_logger.log(Level.FINE, s.toString());
+				LOGGER.log(Level.FINE, s.toString());
 			}
 		}
 		catch(final Exception e)
@@ -86,7 +86,7 @@ public class RtspLoggingHandler extends SimpleChannelHandler
 		final HttpResponse resp = (HttpResponse) evt.getMessage();
 
 		final Level level = Level.FINE;
-		if(s_logger.isLoggable(level))
+		if(LOGGER.isLoggable(level))
 		{
 			final StringBuilder s = new StringBuilder();
 			s.append("<");
@@ -102,7 +102,7 @@ public class RtspLoggingHandler extends SimpleChannelHandler
 				s.append(header.getValue());
 				s.append("\n");
 			}
-			s_logger.log(Level.FINE, s.toString());
+			LOGGER.log(Level.FINE, s.toString());
 		}
 
 		super.writeRequested(ctx, evt);

--- a/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/airreceiver/RtspUnsupportedResponseHandler.java
+++ b/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/airreceiver/RtspUnsupportedResponseHandler.java
@@ -29,14 +29,14 @@ import org.jboss.netty.handler.codec.rtsp.RtspVersions;
  */
 public class RtspUnsupportedResponseHandler extends SimpleChannelUpstreamHandler
 {
-	private static Logger s_logger = Logger.getLogger(RtspUnsupportedResponseHandler.class.getName());
+	private static final Logger LOGGER = Logger.getLogger(RtspUnsupportedResponseHandler.class.getName());
 
 	@Override
 	public void messageReceived(final ChannelHandlerContext ctx, final MessageEvent evt) throws Exception
 	{
 		final HttpRequest req = (HttpRequest) evt.getMessage();
 
-		s_logger.warning("Method " + req.getMethod() + " is not supported");
+		LOGGER.warning("Method " + req.getMethod() + " is not supported");
 
 		final HttpResponse response = new DefaultHttpResponse(RtspVersions.RTSP_1_0, RtspResponseStatuses.METHOD_NOT_VALID);
 		ctx.getChannel().write(response);

--- a/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/audio/JavaSoundSink.java
+++ b/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/server/audio/JavaSoundSink.java
@@ -25,7 +25,7 @@ import javax.sound.sampled.*;
 
 public class JavaSoundSink implements SampleClock
 {
-	private static Logger s_logger = Logger.getLogger(JavaSoundSink.class.getName());
+	private static final Logger LOGGER = Logger.getLogger(JavaSoundSink.class.getName());
 
 	private static final double TimeOffset = 2208988800.0;
 
@@ -114,7 +114,7 @@ public class JavaSoundSink implements SampleClock
 								}
 								catch(InterruptedException e)
 								{
-									s_logger.log(Level.WARNING, "Java Sound line writer was interrupted during startup", e);
+									LOGGER.log(Level.WARNING, "Java Sound line writer was interrupted during startup", e);
                                     Thread.currentThread().interrupt();
 									throw new RuntimeException(e.getMessage(), e);
 								}
@@ -163,13 +163,13 @@ public class JavaSoundSink implements SampleClock
 						{
 							mute();
 							lineIsPaused = true;
-							s_logger.log(Level.INFO, "Audio output paused at " + m_lineEndTime);
+							LOGGER.log(Level.INFO, "Audio output paused at " + m_lineEndTime);
 						}
 						else
 						{
 							unmute();
 							lineIsPaused = false;
-							s_logger.log(Level.INFO, "Audio output resumed at " + m_lineEndTime);
+							LOGGER.log(Level.INFO, "Audio output resumed at " + m_lineEndTime);
 						}
 					}
 
@@ -194,13 +194,13 @@ public class JavaSoundSink implements SampleClock
 							{
 								unmute();
 								lineIsMuted = false;
-								s_logger.log(Level.WARNING, "Audio sample source resumed providing samples at " + m_lineEndTime + ", un-muted line");
+								LOGGER.log(Level.WARNING, "Audio sample source resumed providing samples at " + m_lineEndTime + ", un-muted line");
 							}
 							else
 							{
 								mute();
 								lineIsMuted = true;
-								s_logger.log(Level.WARNING, "Audio sample source stopped providing samples at " + m_lineEndTime + ", muted line");
+								LOGGER.log(Level.WARNING, "Audio sample source stopped providing samples at " + m_lineEndTime + ", muted line");
 							}
 						}
 					}
@@ -230,18 +230,18 @@ public class JavaSoundSink implements SampleClock
 					{
 						if(skipSamples >= sampleSourceBuffer.getDimensions().samples)
 						{
-							s_logger.warning("Audio output overlaps " + skipSamples + " samples, ignored buffer");
+							LOGGER.warning("Audio output overlaps " + skipSamples + " samples, ignored buffer");
 						}
 						else if(silenceSamples >= sampleSourceBuffer.getDimensions().samples)
 						{
-							s_logger.warning("Audio output has gap of " + silenceSamples + " samples, ignored buffer");
+							LOGGER.warning("Audio output has gap of " + silenceSamples + " samples, ignored buffer");
 						}
 						else
 						{
 							if(skipSamples > 0)
-								s_logger.warning("Audio output overlaps " + skipSamples + " samples, skipped samples");
+								LOGGER.warning("Audio output overlaps " + skipSamples + " samples, skipped samples");
 							if(silenceSamples > 0)
-								s_logger.warning("Audio output has gap of " + silenceSamples + " samples, filled with silence");
+								LOGGER.warning("Audio output has gap of " + silenceSamples + " samples, filled with silence");
 
 							advanceEndTime(write(sampleSourceBuffer.slice(new SampleOffset(0, skipSamples), sampleSourceBuffer.getDimensions().reduce(0, skipSamples))));
 						}

--- a/jolivia.daap/src/main/java/org/dyndns/jkiddo/service/daap/server/DAAPResource.java
+++ b/jolivia.daap/src/main/java/org/dyndns/jkiddo/service/daap/server/DAAPResource.java
@@ -66,7 +66,7 @@ import com.google.common.collect.Iterables;
 @Consumes(MediaType.WILDCARD)
 // @Produces(MediaType.WILDCARD)
 public class DAAPResource extends DMAPResource<IItemManager> implements IMusicLibrary {
-	private static final Logger logger = LoggerFactory.getLogger(DAAPResource.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(DAAPResource.class);
 
 	public static final String DAAP_PORT_NAME = "DAAP_PORT_NAME";
 	public static final String DAAP_RESOURCE = "DAAP_IMPLEMENTATION";

--- a/jolivia.daap/src/main/java/org/dyndns/jkiddo/service/daap/server/MusicItemManager.java
+++ b/jolivia.daap/src/main/java/org/dyndns/jkiddo/service/daap/server/MusicItemManager.java
@@ -54,7 +54,7 @@ import com.j256.ormlite.table.TableUtils;
 
 public class MusicItemManager implements IItemManager
 {
-	private static final Logger logger = LoggerFactory.getLogger(MusicItemManager.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(MusicItemManager.class);
 
 	private final IMusicStoreReader reader;
 	// private final Map<MediaItem, IMusicItem> itemToIMusicItem;

--- a/jolivia.dacp/src/main/java/org/dyndns/jkiddo/service/daap/client/Library.java
+++ b/jolivia.dacp/src/main/java/org/dyndns/jkiddo/service/daap/client/Library.java
@@ -48,7 +48,7 @@ import org.slf4j.LoggerFactory;
 public class Library
 {
 
-	public final static Logger logger = LoggerFactory.getLogger(Library.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(Library.class);
 
 	private final Session session;
 

--- a/jolivia.dacp/src/main/java/org/dyndns/jkiddo/service/daap/client/PairedRemoteDiscoverer.java
+++ b/jolivia.dacp/src/main/java/org/dyndns/jkiddo/service/daap/client/PairedRemoteDiscoverer.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
 @Singleton
 public class PairedRemoteDiscoverer implements IDiscoverer
 {
-	public static final Logger logger = LoggerFactory.getLogger(PairedRemoteDiscoverer.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(PairedRemoteDiscoverer.class);
 
 	private final IZeroconfManager mDNS;
 	private final IPairingDatabase database;
@@ -51,18 +51,18 @@ public class PairedRemoteDiscoverer implements IDiscoverer
 	@Override
 	public void serviceAdded(final ServiceEvent event)
 	{
-		logger.info("ADD: " + event.getDNS().getServiceInfo(event.getType(), event.getName()));
+		LOGGER.info("ADD: " + event.getDNS().getServiceInfo(event.getType(), event.getName()));
 		//serviceResolved(event);
 	}
 
 	@Override
 	public void serviceRemoved(final ServiceEvent event)
 	{
-		logger.info("REMOVE: " + event.getDNS().getServiceInfo(event.getType(), event.getName()));
+		LOGGER.info("REMOVE: " + event.getDNS().getServiceInfo(event.getType(), event.getName()));
 		final String code = database.findCode(event.getInfo().getName());
 		if(code != null)
 		{
-			logger.debug("Unpairing ... ");
+			LOGGER.debug("Unpairing ... ");
 			this.clientSessionListener.tearDownSession(event.getInfo().getServer(), event.getInfo().getPort());	
 		}
 	}
@@ -70,14 +70,14 @@ public class PairedRemoteDiscoverer implements IDiscoverer
 	@Override
 	public void serviceResolved(final ServiceEvent event)
 	{
-		logger.info("ADD: " + event.getDNS().getServiceInfo(event.getType(), event.getName()));
+		LOGGER.info("ADD: " + event.getDNS().getServiceInfo(event.getType(), event.getName()));
 
 		final String code = database.findCode(event.getInfo().getName());
 		if(code != null)
 		{
 			try
 			{
-				logger.debug("About to pair with " + event.getInfo().getServer());
+				LOGGER.debug("About to pair with " + event.getInfo().getServer());
 				// If code is != null, we previously have been paired with this library. It does not mean that we still are.
 				final String host;
 				// if(!Strings.isNullOrEmpty(event.getInfo().getServer()))
@@ -89,13 +89,13 @@ public class PairedRemoteDiscoverer implements IDiscoverer
 			}
 			catch(final Exception e)
 			{
-				logger.warn("Could not establish session with client - erasing previously submitted code", e);
+				LOGGER.warn("Could not establish session with client - erasing previously submitted code", e);
 				database.updateCode(event.getInfo().getName(), null);
 			}
 		}
 		else
 		{
-			logger.debug("No matching code could be found to service: " + event.getInfo().getName());
+			LOGGER.debug("No matching code could be found to service: " + event.getInfo().getName());
 		}
 	}
 
@@ -104,7 +104,7 @@ public class PairedRemoteDiscoverer implements IDiscoverer
 	{
 		final JmDNS mdns = event.getDNS();
 		final InetAddress address = event.getInetAddress();
-		logger.info("Registered PairedRemoteDiscoverer @ " + address.getHostAddress());
+		LOGGER.info("Registered PairedRemoteDiscoverer @ " + address.getHostAddress());
 		mdns.addServiceListener(ITouchAbleServerResource.TOUCH_ABLE_SERVER, this);
 		mdns.addServiceListener(ITouchAbleServerResource.DACP_TYPE, this);
 		mdns.addServiceListener(ITouchRemoteResource.TOUCH_REMOTE_CLIENT, this);

--- a/jolivia.dacp/src/main/java/org/dyndns/jkiddo/service/daap/client/RemoteControl.java
+++ b/jolivia.dacp/src/main/java/org/dyndns/jkiddo/service/daap/client/RemoteControl.java
@@ -60,7 +60,7 @@ import com.google.common.collect.Lists;
  */
 public class RemoteControl
 {
-	public static final Logger logger = LoggerFactory.getLogger(RemoteControl.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(RemoteControl.class);
 
 	private final Session session;
 
@@ -258,7 +258,7 @@ public class RemoteControl
 		}
 		catch(final IOException e)
 		{
-			logger.debug(e.getMessage(), e);
+			LOGGER.debug(e.getMessage(), e);
 			return getNowPlaying();
 		}
 	}
@@ -299,7 +299,7 @@ public class RemoteControl
 	{
 		if(volume > 100 || volume < 0)
 		{
-			logger.debug("Volume should be in the range 0 to 100");
+			LOGGER.debug("Volume should be in the range 0 to 100");
 		}
 		// http://192.168.254.128:3689/ctrl-int/1/setproperty?dmcp.volume=100.000000&session-id=130883770
 		RequestHelper.dispatch(String.format("%s/ctrl-int/1/setproperty?dmcp.volume=%s&session-id=%s", session.getRequestBase(), volume, session.getSessionId()));

--- a/jolivia.dacp/src/main/java/org/dyndns/jkiddo/service/daap/client/RequestHelper.java
+++ b/jolivia.dacp/src/main/java/org/dyndns/jkiddo/service/daap/client/RequestHelper.java
@@ -58,7 +58,7 @@ public final class RequestHelper
 	private static final int CONNECT_TIMEOUT = 10000;
 	private static final int READ_TIMEOUT = 0; // Infinite
 
-	public final static Logger logger = LoggerFactory.getLogger(RequestHelper.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(RequestHelper.class);
 
 	private RequestHelper() throws InstantiationException {
 		throw new InstantiationException("This class is not created for instantiation");
@@ -87,7 +87,7 @@ public final class RequestHelper
 	@SuppressWarnings("unchecked")
 	public static <T extends Chunk> T requestParsed(final String url, final boolean keepalive, final boolean specialCaseProtocolViolation) throws Exception
 	{
-		logger.debug(url);
+		LOGGER.debug(url);
 		final DmapInputStream inputStream = new DmapInputStream(new ByteArrayInputStream(request(url, keepalive)), specialCaseProtocolViolation);
 		final Chunk chunk = inputStream.getChunk();
 		Closeables.close(inputStream, true);
@@ -162,7 +162,7 @@ public final class RequestHelper
 	 */
 	private static byte[] request(final String remoteUrl, final boolean keepalive) throws Exception
 	{
-		logger.debug(String.format("started request(remote=%s)", remoteUrl));
+		LOGGER.debug(String.format("started request(remote=%s)", remoteUrl));
 
 		final byte[] buffer = new byte[1024];
 
@@ -257,7 +257,7 @@ public final class RequestHelper
 		}
 		catch(final UnsupportedEncodingException e)
 		{
-			logger.warn("escapeUrlString Exception:" + e.getMessage());
+			LOGGER.warn("escapeUrlString Exception:" + e.getMessage());
 		}
 		return encoded;
 	}

--- a/jolivia.dacp/src/main/java/org/dyndns/jkiddo/service/daap/client/Session.java
+++ b/jolivia.dacp/src/main/java/org/dyndns/jkiddo/service/daap/client/Session.java
@@ -67,7 +67,7 @@ import com.google.common.collect.Lists;
 
 public class Session
 {
-	public final static Logger logger = LoggerFactory.getLogger(Session.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(Session.class);
 
 	private final String host;
 	private long revision = 1;
@@ -92,7 +92,7 @@ public class Session
 
 		getServerInfo();
 
-		logger.debug(String.format("trying login for host=%s", host));
+		LOGGER.debug(String.format("trying login for host=%s", host));
 		final NSDictionary nsDic = Util.requestPList(username, password);
 		homeSharingGid = "&hsgid=" + ((NSString) nsDic.get("sgid")).getContent();
 		final LoginResponse loginResponse = doLoginWithHomeSharingGid(((NSString) nsDic.get("sgid")).getContent());
@@ -135,7 +135,7 @@ public class Session
 		getServerInfo();
 
 		// http://192.168.254.128:3689/login?pairing-guid=0x0000000000000001
-		logger.debug(String.format("trying login for host=%s and guid=%s", host, pairingGuid));
+		LOGGER.debug(String.format("trying login for host=%s and guid=%s", host, pairingGuid));
 		final LoginResponse loginResponse = doLogin(pairingGuid);
 
 		sessionId = loginResponse.getSessionId().getValue();
@@ -200,7 +200,7 @@ public class Session
 		}
 		catch(final NoSuchElementException nee)
 		{
-			logger.debug("No radio databases found", nee);
+			LOGGER.debug("No radio databases found", nee);
 			return null;
 		}
 

--- a/jolivia.dacp/src/main/java/org/dyndns/jkiddo/service/daap/client/UnpairedRemoteCrawler.java
+++ b/jolivia.dacp/src/main/java/org/dyndns/jkiddo/service/daap/client/UnpairedRemoteCrawler.java
@@ -24,7 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class UnpairedRemoteCrawler implements IDiscoverer {
-	public static final Logger logger = LoggerFactory
+	private static final Logger LOGGER = LoggerFactory
 			.getLogger(UnpairedRemoteCrawler.class);
 
 	public static final String SERVICE_PORT_NAME = "SERVICE_PORT_NAME";
@@ -51,19 +51,19 @@ public class UnpairedRemoteCrawler implements IDiscoverer {
 
 	@Override
 	public void serviceAdded(final ServiceEvent event) {
-		logger.info("ADD: "
+		LOGGER.info("ADD: "
 				+ event.getDNS().getServiceInfo(event.getType(),
 						event.getName()));
 	}
 
 	@Override
 	public void serviceRemoved(final ServiceEvent event) {
-		logger.debug("REMOVE: " + event.getName());
+		LOGGER.debug("REMOVE: " + event.getName());
 	}
 
 	@Override
 	public void serviceResolved(final ServiceEvent event) {
-		logger.info("ADD: "
+		LOGGER.info("ADD: "
 				+ event.getDNS().getServiceInfo(event.getType(),
 						event.getName()));
 
@@ -100,7 +100,7 @@ public class UnpairedRemoteCrawler implements IDiscoverer {
 	public void inetAddressAdded(final NetworkTopologyEvent event) {
 		final JmDNS mdns = event.getDNS();
 		final InetAddress address = event.getInetAddress();
-		logger.info("Registered PairedRemoteDiscoverer @ "
+		LOGGER.info("Registered PairedRemoteDiscoverer @ "
 				+ address.getHostAddress());
 		mdns.addServiceListener(ITouchRemoteResource.TOUCH_REMOTE_CLIENT, this);
 		interfaces.put(mdns, address);

--- a/jolivia.dacp/src/main/java/org/dyndns/jkiddo/service/dacp/client/TouchRemoteResource.java
+++ b/jolivia.dacp/src/main/java/org/dyndns/jkiddo/service/dacp/client/TouchRemoteResource.java
@@ -54,7 +54,7 @@ public class TouchRemoteResource extends MDNSResource implements ITouchRemoteRes
 	public static final String DACP_CLIENT_PORT_NAME = "DACP_CLIENT_PORT_NAME";
 	public static final String DACP_CLIENT_PAIRING_CODE = "DACP_CLIENT_PAIRING_CODE";
 
-	public final static Logger logger = LoggerFactory.getLogger(TouchRemoteResource.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(TouchRemoteResource.class);
 
 	private final IPairingDatabase database;
 	private final Integer actualCode;
@@ -71,7 +71,7 @@ public class TouchRemoteResource extends MDNSResource implements ITouchRemoteRes
 		}
 		catch(final NoSuchAlgorithmException e)
 		{
-			logger.error(e.getMessage(), e);
+			LOGGER.error(e.getMessage(), e);
 		}
 	}
 
@@ -149,7 +149,7 @@ public class TouchRemoteResource extends MDNSResource implements ITouchRemoteRes
 	@Override
 	public void serviceRemoved(final ServiceEvent event)
 	{
-		logger.info("REMOVE: " + event.getDNS().getServiceInfo(event.getType(), event.getName()));
+		LOGGER.info("REMOVE: " + event.getDNS().getServiceInfo(event.getType(), event.getName()));
 		try
 		{
 			final String code = database.findCode(event.getInfo().getName());
@@ -162,7 +162,7 @@ public class TouchRemoteResource extends MDNSResource implements ITouchRemoteRes
 		}
 		catch(final IOException e)
 		{
-			logger.debug(e.getMessage(), e);
+			LOGGER.debug(e.getMessage(), e);
 		}
 	}
 
@@ -175,7 +175,7 @@ public class TouchRemoteResource extends MDNSResource implements ITouchRemoteRes
 	{
 		final JmDNS mdns = event.getDNS();
 		final InetAddress address = event.getInetAddress();
-		logger.info("Registered PairedRemoteDiscoverer @ " + address.getHostAddress());
+		LOGGER.info("Registered PairedRemoteDiscoverer @ " + address.getHostAddress());
 		mdns.addServiceListener(ITouchAbleServerResource.TOUCH_ABLE_SERVER, this);
 	}
 

--- a/jolivia.dmap/src/main/java/org/dyndns/jkiddo/service/dmap/MDNSResource.java
+++ b/jolivia.dmap/src/main/java/org/dyndns/jkiddo/service/dmap/MDNSResource.java
@@ -22,7 +22,7 @@ public abstract class MDNSResource
 	private final IZeroconfManager mDNS;
 	protected Integer port;
 
-	private static final Logger logger = LoggerFactory.getLogger(MDNSResource.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(MDNSResource.class);
 	public final String hostname = InetAddress.getLocalHost().getHostName();
 	
 	public static final String MACHINE_ID_KEY = "Machine ID";

--- a/jolivia.dmap/src/main/java/org/dyndns/jkiddo/service/dmap/Util.java
+++ b/jolivia.dmap/src/main/java/org/dyndns/jkiddo/service/dmap/Util.java
@@ -48,7 +48,7 @@ public class Util
 {
 	public static final String APPLICATION_NAME = "APPLICATION_NAME";
 	public static final String APPLICATION_X_DMAP_TAGGED = "application/x-dmap-tagged";
-	private static final Logger logger = LoggerFactory.getLogger(Util.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(Util.class);
 
 	private static final int PARTIAL_CONTENT = 206;
 
@@ -212,7 +212,7 @@ public class Util
 					final byte[] ifaceMacAddress = iface.getHardwareAddress();
 					if((ifaceMacAddress != null) && (ifaceMacAddress.length == 6) && !isBlockedHardwareAddress(ifaceMacAddress))
 					{
-						logger.info("Hardware address is " + toHexString(ifaceMacAddress) + " (" + iface.getDisplayName() + ")");
+						LOGGER.info("Hardware address is " + toHexString(ifaceMacAddress) + " (" + iface.getDisplayName() + ")");
 						return Arrays.copyOfRange(ifaceMacAddress, 0, 6);
 					}
 				}
@@ -231,7 +231,7 @@ public class Util
 		try
 		{
 			final byte[] hostAddress = Arrays.copyOfRange(InetAddress.getLocalHost().getAddress(), 0, 6);
-			logger.info("Hardware address is " + toHexString(hostAddress) + " (IP address)");
+			LOGGER.info("Hardware address is " + toHexString(hostAddress) + " (IP address)");
 			return hostAddress;
 		}
 		catch(final Throwable e)
@@ -240,7 +240,7 @@ public class Util
 		}
 
 		/* Fallback to a constant */
-		logger.info("Hardware address is 00DEADBEEF00 (last resort)");
+		LOGGER.info("Hardware address is 00DEADBEEF00 (last resort)");
 		return new byte[] { (byte) 0x00, (byte) 0xDE, (byte) 0xAD, (byte) 0xBE, (byte) 0xEF, (byte) 0x00 };
 	}
 

--- a/jolivia.dmap/src/main/java/org/dyndns/jkiddo/zeroconf/ZeroconfManagerImpl.java
+++ b/jolivia.dmap/src/main/java/org/dyndns/jkiddo/zeroconf/ZeroconfManagerImpl.java
@@ -12,7 +12,7 @@ import org.slf4j.LoggerFactory;
 
 public class ZeroconfManagerImpl implements IZeroconfManager, NetworkTopologyListener
 {
-	private static final Logger logger = LoggerFactory.getLogger(ZeroconfManagerImpl.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(ZeroconfManagerImpl.class);
 
 	private final JmmDNS mdns;
 	private javax.jmdns.ServiceInfo info;
@@ -51,7 +51,7 @@ public class ZeroconfManagerImpl implements IZeroconfManager, NetworkTopologyLis
 		}
 		catch(final IOException e)
 		{
-			logger.error(e.getMessage(), e);
+			LOGGER.error(e.getMessage(), e);
 		}
 	}
 

--- a/jolivia.dpap/src/main/java/org/dyndns/jkiddo/service/dpap/server/DPAPResource.java
+++ b/jolivia.dpap/src/main/java/org/dyndns/jkiddo/service/dpap/server/DPAPResource.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
 // @Produces(MediaType.WILDCARD)
 public class DPAPResource extends DMAPResource<ImageItemManager> implements IImageLibrary
 {
-	private static final Logger logger = LoggerFactory.getLogger(DPAPResource.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(DPAPResource.class);
 
 	public static final String DPAP_SERVER_PORT_NAME = "DPAP_SERVER_PORT_NAME";
 	public static final String DPAP_RESOURCE = "DPAP_IMPLEMENTATION";

--- a/jolivia.example/src/main/java/org/dyndns/jkiddo/JoliviaMainer.java
+++ b/jolivia.example/src/main/java/org/dyndns/jkiddo/JoliviaMainer.java
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.bridge.SLF4JBridgeHandler;
 
 public final class JoliviaMainer {
-	private static Logger logger = LoggerFactory.getLogger(JoliviaMainer.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(JoliviaMainer.class);
 
 	private JoliviaMainer() throws InstantiationException {
 		throw new InstantiationException("This class is not created for instantiation");

--- a/jolivia.example/src/main/java/org/dyndns/jkiddo/Window.java
+++ b/jolivia.example/src/main/java/org/dyndns/jkiddo/Window.java
@@ -54,7 +54,7 @@ public class Window
 			"a copy of the GNU General Public License\n"
 			+ "along with didms.  If not, see <http://www.gnu.org/licenses/>." + "\n\n";
 
-	private static Logger logger = LoggerFactory.getLogger(Window.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(Window.class);
 
 	private final JFrame mainFormJolivia;
 	private final JTextField txtUsername = new JTextField();
@@ -212,7 +212,7 @@ public class Window
 						}*/
 						catch(Exception e)
 						{
-							logger.error(e.getMessage(), e);
+							LOGGER.error(e.getMessage(), e);
 							onShutdown();
 						}
 					}
@@ -252,7 +252,7 @@ public class Window
 				}
 				catch(Exception e)
 				{
-					logger.error(e.getMessage(), e);
+					LOGGER.error(e.getMessage(), e);
 				}
 			}
 		});
@@ -362,7 +362,7 @@ public class Window
 		}
 		catch(Exception e)
 		{
-			logger.error(e.getMessage(), e);
+			LOGGER.error(e.getMessage(), e);
 		}
 	}
 

--- a/jolivia.example/src/main/java/org/dyndns/jkiddo/logic/desk/DeskImageStoreReader.java
+++ b/jolivia.example/src/main/java/org/dyndns/jkiddo/logic/desk/DeskImageStoreReader.java
@@ -28,7 +28,7 @@ public class DeskImageStoreReader implements IImageStoreReader
 	 * 
 	 */
 	private static final long serialVersionUID = -3205613907987224359L;
-	private static final Logger logger = LoggerFactory.getLogger(DeskImageStoreReader.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(DeskImageStoreReader.class);
 	private Map<IImageItem, File> mapOfImageToFile;
 	private String path;
 
@@ -78,7 +78,7 @@ public class DeskImageStoreReader implements IImageStoreReader
 				}
 			}
 			else
-				logger.debug("Symlink'ish ... " + f.getAbsolutePath());
+				LOGGER.debug("Symlink'ish ... " + f.getAbsolutePath());
 		}
 		else if(isImage(f))
 		{
@@ -138,7 +138,7 @@ public class DeskImageStoreReader implements IImageStoreReader
 	{
 		if(image != null)
 		{
-			logger.debug("Serving " + image.getImageFilename());
+			LOGGER.debug("Serving " + image.getImageFilename());
 		}
 		return mapOfImageToFile.get(image).toURI();
 	}

--- a/jolivia.example/src/main/java/org/dyndns/jkiddo/logic/desk/DeskMusicStoreReader.java
+++ b/jolivia.example/src/main/java/org/dyndns/jkiddo/logic/desk/DeskMusicStoreReader.java
@@ -52,7 +52,7 @@ public class DeskMusicStoreReader implements IMusicStoreReader
 	/**
 	 * 
 	 */
-	private static final Logger logger = LoggerFactory.getLogger(DeskMusicStoreReader.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(DeskMusicStoreReader.class);
 	private Collection<MediaItem> mapOfSongToFile;
 	private final File path;
 	private final Parser parser;
@@ -86,7 +86,7 @@ public class DeskMusicStoreReader implements IMusicStoreReader
 		}
 		catch(final Exception e)
 		{
-			logger.info(e.getMessage(), e);
+			LOGGER.info(e.getMessage(), e);
 		}
 		return mapOfSongToFile;
 	}
@@ -103,7 +103,7 @@ public class DeskMusicStoreReader implements IMusicStoreReader
 				}
 			}
 			else
-				logger.debug("Symlink'ish ... " + f.getAbsolutePath());
+				LOGGER.debug("Symlink'ish ... " + f.getAbsolutePath());
 		}
 		else if(isMusic(f))
 		{
@@ -131,7 +131,7 @@ public class DeskMusicStoreReader implements IMusicStoreReader
 		}
 		catch(final Exception e)
 		{
-			logger.debug(e.getMessage(), e);
+			LOGGER.debug(e.getMessage(), e);
 		}
 		song.setSongAlbum(metadata.get(XMPDM.ALBUM));
 		song.setSongArtist(metadata.get(XMPDM.ARTIST));
@@ -143,7 +143,7 @@ public class DeskMusicStoreReader implements IMusicStoreReader
 		}
 		catch(final Exception e)
 		{
-			logger.debug(e.getMessage(), e);
+			LOGGER.debug(e.getMessage(), e);
 		}
 		try
 		{
@@ -153,7 +153,7 @@ public class DeskMusicStoreReader implements IMusicStoreReader
 		}
 		catch(final Exception e)
 		{
-			logger.debug(e.getMessage(), e);
+			LOGGER.debug(e.getMessage(), e);
 		}
 		song.setExternalIdentifer(file.getAbsolutePath());
 		return song;

--- a/jolivia.jetty/src/main/java/org/dyndns/jkiddo/Jolivia.java
+++ b/jolivia.jetty/src/main/java/org/dyndns/jkiddo/Jolivia.java
@@ -66,7 +66,7 @@ import com.google.inject.servlet.GuiceFilter;
 
 public class Jolivia {
 
-	public static Logger logger = LoggerFactory.getLogger(Jolivia.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(Jolivia.class);
 	private static final String AboutMessage = "Use it only to be disruptive";
 
 	public static class JoliviaBuilder {
@@ -224,7 +224,7 @@ public class Jolivia {
 					frame.setSize(icon.getIconWidth(), icon.getIconHeight());
 					frame.setVisible(true);
 				} catch (final Exception e) {
-					logger.debug(e.getMessage(), e);
+					LOGGER.debug(e.getMessage(), e);
 				}
 			}
 
@@ -246,7 +246,7 @@ public class Jolivia {
 
 		Preconditions.checkArgument(!(builder.pairingCode > 9999 || builder.pairingCode < 0),
 				"Pairingcode must be expressed within 4 ciphers");
-		logger.info("Starting " + builder.name + " on port " + builder.port);
+		LOGGER.info("Starting " + builder.name + " on port " + builder.port);
 		server = new Server(builder.port);
 
 		final ServerConnector dmapConnector = new ServerConnector(server, new DmapConnectionFactory());
@@ -277,7 +277,7 @@ public class Jolivia {
 					getSecurityHandler(username, password, DmapUtil.DAAP_REALM, new DigestAuthenticator()));
 		sch.addServlet(DefaultServlet.class, "/");
 
-		logger.info(builder.name + " started");
+		LOGGER.info(builder.name + " started");
 	}
 
 	public void start() throws Exception {
@@ -402,7 +402,7 @@ public class Jolivia {
 				try {
 					onShutdown();
 				} catch (final Exception e) {
-					logger.info(e.getMessage(), e);
+					LOGGER.info(e.getMessage(), e);
 				}
 				System.exit(0);
 			}

--- a/jolivia.jetty/src/main/java/org/dyndns/jkiddo/guice/JoliviaServer.java
+++ b/jolivia.jetty/src/main/java/org/dyndns/jkiddo/guice/JoliviaServer.java
@@ -52,7 +52,7 @@ import com.sun.jersey.guice.spi.container.servlet.GuiceContainer;
 
 public class JoliviaServer extends GuiceServletContextListener
 {
-	private static final Logger logger = LoggerFactory.getLogger(JoliviaServer.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(JoliviaServer.class);
 
 	private final String DB_NAME = "db";
 	private final Integer hostingPort;
@@ -82,9 +82,9 @@ public class JoliviaServer extends GuiceServletContextListener
 		System.setProperty("java.net.preferIPv6Addresses", "false");
 		h2server = Server.createWebServer(new String[] { "-webPort", "9123", "-webAllowOthers" });
 		h2server.start();
-		logger.info("h2 web server started on port http://" + InetAddress.getLocalHost().getHostName() + ":9123/");
-		logger.info("log in with empty username and password");
-		logger.info(databaseUrl);
+		LOGGER.info("h2 web server started on port http://" + InetAddress.getLocalHost().getHostName() + ":9123/");
+		LOGGER.info("log in with empty username and password");
+		LOGGER.info(databaseUrl);
 
 		this.hostingPort = port;
 		this.pairingCode = pairingCode;
@@ -182,7 +182,7 @@ public class JoliviaServer extends GuiceServletContextListener
 		}
 		catch(final IOException e)
 		{
-			logger.error(e.getMessage(), e);
+			LOGGER.error(e.getMessage(), e);
 		}
 		super.contextDestroyed(servletContextEvent);
 	}

--- a/jolivia.jetty/src/main/java/org/dyndns/jkiddo/jetty/JoliviaExceptionMapper.java
+++ b/jolivia.jetty/src/main/java/org/dyndns/jkiddo/jetty/JoliviaExceptionMapper.java
@@ -25,12 +25,12 @@ import com.sun.jersey.core.spi.factory.ResponseBuilderImpl;
 @Singleton
 public class JoliviaExceptionMapper implements ExceptionMapper<Throwable>
 {
-	private final static Logger logger = LoggerFactory.getLogger(JoliviaExceptionMapper.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(JoliviaExceptionMapper.class);
 
 	@Override
 	public Response toResponse(Throwable exception)
 	{
-		logger.warn(exception.getMessage(), exception);
+		LOGGER.warn(exception.getMessage(), exception);
 		return new ResponseBuilderImpl().status(Status.INTERNAL_SERVER_ERROR).build();
 	}
 }

--- a/jolivia.jetty/src/main/java/org/dyndns/jkiddo/jetty/ProxyFilter.java
+++ b/jolivia.jetty/src/main/java/org/dyndns/jkiddo/jetty/ProxyFilter.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
 @Singleton
 public class ProxyFilter implements Filter
 {
-	private static Logger logger = LoggerFactory.getLogger(ProxyFilter.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(ProxyFilter.class);
 
 	//http://simplapi.wordpress.com/2013/01/24/jersey-jax-rs-implements-a-http-basic-auth-decoder/
 		
@@ -53,11 +53,11 @@ public class ProxyFilter implements Filter
 		while(headerNames.hasMoreElements())
 		{
 			final String headerName = headerNames.nextElement();
-			logger.info(headerName + ": " + httpServletRequest.getHeader(headerName));
+			LOGGER.info(headerName + ": " + httpServletRequest.getHeader(headerName));
 		}
 
-		logger.info(httpServletRequest.getRequestURI() + queryString);
-		logger.info("");
+		LOGGER.info(httpServletRequest.getRequestURI() + queryString);
+		LOGGER.info("");
 		chain.doFilter(request, response);
 	}
 

--- a/jolivia.jetty/src/main/java/org/eclipse/jetty/http/DmapParser.java
+++ b/jolivia.jetty/src/main/java/org/eclipse/jetty/http/DmapParser.java
@@ -26,7 +26,7 @@ import org.eclipse.jetty.util.log.Logger;
 
 public class DmapParser extends HttpParser{
 
-	 public static final Logger LOG = Log.getLogger(HttpParser.class);
+	 private static final Logger LOG = Log.getLogger(HttpParser.class);
 	    @Deprecated
 	    public final static String __STRICT="org.eclipse.jetty.http.HttpParser.STRICT";
 	    public final static int INITIAL_URI_LENGTH=256;

--- a/jolivia.protocol/src/main/java/org/dyndns/jkiddo/dmp/DmapInputStream.java
+++ b/jolivia.protocol/src/main/java/org/dyndns/jkiddo/dmp/DmapInputStream.java
@@ -53,7 +53,7 @@ import org.slf4j.LoggerFactory;
 public class DmapInputStream extends BufferedInputStream
 {
 
-	private static final Logger logger = LoggerFactory.getLogger(DmapInputStream.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(DmapInputStream.class);
 
 	private ChunkFactory factory;
 
@@ -240,7 +240,7 @@ public class DmapInputStream extends BufferedInputStream
 					}
 					catch(final ProtocolViolationException pve)
 					{
-						logger.warn(pve.getMessage(), pve);
+						LOGGER.warn(pve.getMessage(), pve);
 						in.skip(in.getChunkContentLength());
 					}
 					//
@@ -264,13 +264,13 @@ public class DmapInputStream extends BufferedInputStream
 	 */
 	private static void checkLength(final Chunk chunk, final int expected, final int length)
 	{
-		if (expected != length && logger.isWarnEnabled())
+		if (expected != length && LOGGER.isWarnEnabled())
 		{
 			// throw new IOException("Expected a chunk with length " + expected
 			// + " but got " + length + " (" + chunk.getContentCodeString() +
 			// ")");
 
-			logger.warn("Expected a chunk with length " + expected + " but got " + length + " (" + chunk.getContentCodeString() + ") " + chunk.getClass());
+			LOGGER.warn("Expected a chunk with length " + expected + " but got " + length + " (" + chunk.getContentCodeString() + ") " + chunk.getClass());
 		}
 	}
 }

--- a/jolivia.protocol/src/main/java/org/dyndns/jkiddo/dmp/chunks/UIntChunk.java
+++ b/jolivia.protocol/src/main/java/org/dyndns/jkiddo/dmp/chunks/UIntChunk.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
 public abstract class UIntChunk extends AbstractChunk implements IntChunk
 {
 
-	private static final Logger logger = LoggerFactory.getLogger(UIntChunk.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(UIntChunk.class);
 
 	public static final long MIN_VALUE = 0l;
 	public static final long MAX_VALUE = 0xFFFFFFFFl;
@@ -85,7 +85,7 @@ public abstract class UIntChunk extends AbstractChunk implements IntChunk
 	{
 		if(value < MIN_VALUE || value > MAX_VALUE)
 		{
-			logger.error("Value is outside of unsigned int range: " + value);
+			LOGGER.error("Value is outside of unsigned int range: " + value);
 		}
 		return value;
 	}

--- a/jolivia.protocol/src/main/java/org/dyndns/jkiddo/dmp/chunks/media/Listing.java
+++ b/jolivia.protocol/src/main/java/org/dyndns/jkiddo/dmp/chunks/media/Listing.java
@@ -49,7 +49,7 @@ import org.dyndns.jkiddo.dmp.DMAPAnnotation;
 @DMAPAnnotation(type=DmapChunkDefinition.mlcl)
 public class Listing extends ContainerChunk
 {
-	public final static Logger logger = LoggerFactory.getLogger(Listing.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(Listing.class);
 
 	public Listing()
 	{
@@ -88,7 +88,7 @@ public class Listing extends ContainerChunk
 		}
 		if(Iterables.size(filteredItems) > 1)
 		{
-			logger.info("Found more than one ListingItem fullfilling predicate - returning the first one");
+			LOGGER.info("Found more than one ListingItem fullfilling predicate - returning the first one");
 		}
 
 		return filteredItems.iterator().next();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1312 - Loggers should be "private static final" and should share a naming convention

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1312

Please let me know if you have any questions.

M-Ezzat