### PR TITLE
Cleanup - squid:S1943 - Classes and methods that rely on the default …

### DIFF
--- a/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/client/model/DeviceConnection.java
+++ b/jolivia.airplay/src/main/java/org/dyndns/jkiddo/raop/client/model/DeviceConnection.java
@@ -3,6 +3,7 @@ package org.dyndns.jkiddo.raop.client.model;
 
 import java.net.Socket;
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Logger;
 import java.util.logging.Level;
 
@@ -56,8 +57,10 @@ public class DeviceConnection
 
 		try
 		{
-			BufferedReader deviceInput = new BufferedReader(new InputStreamReader(socket.getInputStream()));
-			BufferedWriter deviceOutput = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream()));
+			BufferedReader deviceInput = new BufferedReader(
+                    new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8));
+			BufferedWriter deviceOutput = new BufferedWriter(
+                    new OutputStreamWriter(socket.getOutputStream(), StandardCharsets.UTF_8));
 
 			String commandString = command.getCommandString();
 			deviceOutput.write(commandString + "\n");

--- a/jolivia.dacp/src/main/java/org/dyndns/jkiddo/service/daap/client/Session.java
+++ b/jolivia.dacp/src/main/java/org/dyndns/jkiddo/service/daap/client/Session.java
@@ -36,6 +36,7 @@
 package org.dyndns.jkiddo.service.daap.client;
 
 import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -348,7 +349,7 @@ public class Session
 
 		final byte[] value = new byte[] { 2, 0, 2, (byte) 187 };
 		final byte[] nr = { 1 };
-		final ArrayList<byte[]> bytes = Lists.newArrayList("FPLYd".getBytes(), new byte[] { 1 }, nr, new byte[] { 0, 0, 0, 0 }, new byte[] { (byte) value.length }, value);
+		final ArrayList<byte[]> bytes = Lists.newArrayList("FPLYd".getBytes(StandardCharsets.UTF_8), new byte[] { 1 }, nr, new byte[] { 0, 0, 0, 0 }, new byte[] { (byte) value.length }, value);
 		cert = RequestHelper.requestPost(String.format("%s/fp-setup?session-id=%s" + homeSharingGid, this.getRequestBase(), this.sessionId), concatenateByteArrays(bytes));
 		System.out.println(Util.toHex(cert));
 		return;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1943 - Classes and methods that rely on the default system encoding should not be used

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1943

Please let me know if you have any questions.

M-Ezzat